### PR TITLE
Fix for overrides wrapping from minimum to maximum rate

### DIFF
--- a/planner.c
+++ b/planner.c
@@ -565,7 +565,7 @@ void plan_cycle_reinitialize ()
 }
 
 // Set feed overrides
-void plan_feed_override (uint_fast8_t feed_override, uint_fast8_t rapid_override)
+void plan_feed_override (int_fast16_t feed_override, int_fast16_t rapid_override)
 {
     if(sys.override.control.feed_rate_disable)
         return;

--- a/planner.h
+++ b/planner.h
@@ -144,6 +144,6 @@ uint_fast16_t plan_get_block_buffer_available();
 // Returns the status of the block ring buffer. True, if buffer is full.
 bool plan_check_full_buffer();
 
-void plan_feed_override (uint_fast8_t feed_override, uint_fast8_t rapid_override);
+void plan_feed_override (int_fast16_t feed_override, int_fast16_t rapid_override);
 
 #endif

--- a/spindle_control.c
+++ b/spindle_control.c
@@ -29,7 +29,7 @@
 
 // Set spindle speed override
 // NOTE: Unlike motion overrides, spindle overrides do not require a planner reinitialization.
-void spindle_set_override (uint_fast8_t speed_override)
+void spindle_set_override (int_fast16_t speed_override)
 {
     if(sys.override.control.spindle_rpm_disable)
         return;

--- a/spindle_control.h
+++ b/spindle_control.h
@@ -78,7 +78,7 @@ typedef enum {
     SpindleData_AngularPosition //!< 2
 } spindle_data_request_t;
 
-void spindle_set_override (uint_fast8_t speed_override);
+void spindle_set_override (int_fast16_t speed_override);
 
 // Called by g-code parser when setting spindle state and requires a buffer sync.
 // Immediately sets spindle running state with direction and spindle RPM, if enabled.


### PR DESCRIPTION
Overrides can wrap around to the maximum rate if multiple CMD_OVERRIDE_xx_MINUS commands are queued while
already at, or near to, the minimum rate. This can occur when using an encoder if moved too quickly.

This happens because the arguments to plan_feed_override() and spindle_set_override() are unsigned. If
(for instance) the override rate is 10, and commands from 11 negative encoder ticks are enqueued before
processing, then the requested override wraps round to a large positive number, and is capped at the
max override value.