### PR TITLE
Add definition for STM32H743xx series processors

### DIFF
--- a/platform.h
+++ b/platform.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if defined(STM32F103xB) || defined(STM32F103xE) || defined(STM32F401xC) || defined(STM32F401xE) ||  defined(STM32F407xx) || defined(STM32F411xE) || defined(STM32F446xx) || defined(STM32F756xx)
+#if defined(STM32F103xB) || defined(STM32F103xE) || defined(STM32F401xC) || defined(STM32F401xE) ||  defined(STM32F407xx) || defined(STM32F411xE) || defined(STM32F446xx) || defined(STM32F756xx) || defined(STM32H743xx)
 #define STM32_PLATFORM
 #endif
 


### PR DESCRIPTION
I've started a port for the STM32H7xx series processors, based on your F7 driver. This request just adds the 743xx to the core as a known STM32 platform.

