### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I have only bench tested this for a couple of drivers, correct function should b
 More details in the [changelog](changelog.md).
 
 ---
-Updated for lates core changes.
+Updated for latest core changes.
 __NOTE:__ Arduino drivers has now been converted to Arduino libraries, [installation and compilation procedure](https://github.com/grblHAL/core/wiki/Compiling-GrblHAL) has been changed!
 
 ---

--- a/changelog.md
+++ b/changelog.md
@@ -192,7 +192,7 @@ Note that timer 2 is a 16 bit timer that had to be extended virtually to 32 bit 
 
 Templates:
 
-* Added plugin for Marlin style M17/M18 (M84) commands for enabing/disabling stepper drivers as fix for issue #184. 
+* Added plugin for Marlin style M17/M18 (M84) commands for enabling/disabling stepper drivers as fix for issue #184. 
 
 ---
 
@@ -908,7 +908,7 @@ Build 20210726:
 Core:
 * Added encapsulation in stream handlers for realtime processing. This allows more flexible use of additional streams.
 * Added optional debug stream to the HAL. Currently only used by the iMXRT1062 driver.
-* Position will now be recalulated on steps/mm setting changes.
+* Position will now be recalculated on steps/mm setting changes.
 * Limited final `$TPW` retract on tool changes to Z home to avoid triggering Z-limit.
 * Moved some common driver code snippets to the core to avoid duplication.
 
@@ -931,25 +931,25 @@ Core:
 Drivers:
 * Updated a number of drivers for new style pin handling (allows `$pins` report and simpler pin mapping files).
 * Updated and verified driver for RP2040, mainly to support the PicoCNC board.
-* Added/improved interrupt support for auxillary inputs for both plugin code (via API) and for `M66`.
+* Added/improved interrupt support for auxiliary inputs for both plugin code (via API) and for `M66`.
 * Bug fixes.
 
 Build 20210626:
 * Standardized handling of motors for ABC- and ganged/squared axes, configuration moved to _my_machine.h_.  
 First number of motors required is calculated, then ABC axes are added from bottom up and then ganged/squared axes from top down.  
 E.g if the board map supports six motors then the following allocations will be made:  
-A-axis and auto-squared Y axis: A-axis -> motor 4 and second Y-axis -> motor 5. Motor 6 pins may then be assigned to auxillary I/O.  
-A-axis, B-axis and ganged X-axis: A-axis -> motor 4 and, B-axis -> motor 5 and second X-axis -> motor 6. Motor 6 limit pin\(s\) if available may be assigned to auxillary I/O.  
-Auto-squared X and Y-axis: second X-axis -> motor 4 and second Y-axis -> motor 5. Motor 6 pins may then be assigned to auxillary I/O.  
+A-axis and auto-squared Y axis: A-axis -> motor 4 and second Y-axis -> motor 5. Motor 6 pins may then be assigned to auxiliary I/O.  
+A-axis, B-axis and ganged X-axis: A-axis -> motor 4 and, B-axis -> motor 5 and second X-axis -> motor 6. Motor 6 limit pin\(s\) if available may be assigned to auxiliary I/O.  
+Auto-squared X and Y-axis: second X-axis -> motor 4 and second Y-axis -> motor 5. Motor 6 pins may then be assigned to auxiliary I/O.  
 etc...  
 __IMPORTANT:__ For those who have used auto-squared/ganged axes with previous builds be sure to check that the motors allocated matches the current wiring.
-Tip: use the `$pins` system command to list the pin allocations when checking. Rewire as neccesary. 
+Tip: use the `$pins` system command to list the pin allocations when checking. Rewire as necessary. 
 * Added ganged axis/auto-squaring support to some board maps for the [LPC176x](https://github.com/grblHAL/LPC176x) driver.
 * Expanded on HAL entry points for stream communication and added [initial documentation](http://svn.io-engineering.com/grblHAL/html/hal_8h.html) for the HAL and parts of the core.
-* Encapsulated UART/USB CDC code for many drivers, for most only the init function is now available for direct acccess from the outside. Simplified main driver code and plugins using streams.  
+* Encapsulated UART/USB CDC code for many drivers, for most only the init function is now available for direct access from the outside. Simplified main driver code and plugins using streams.  
 __NOTE:__ For driver developers: `hal.stream.get_rx_buffer_available` has been renamed to `hal.stream.get_rx_buffer_free` as it was ambiguous \(free space vs. available characters\).
 * Added preview version of [Bluetooth plugin](https://github.com/grblHAL/Plugins_Bluetooth/) - allows auto configuration and auto stream switching for drivers/boards that supports it.
-* Added number of auxillary I/O ports available to `$I` command response.
+* Added number of auxiliary I/O ports available to `$I` command response.
 * Added value read from last `M66` to the first real-time report following the read. The element `|In:<value>` is used for the report. If the value reported is `-1` the read failed.
 
 ---
@@ -1000,7 +1000,7 @@ Added `$LEV` command for outputting report containing which limit or control swi
 Report format:  
 `[LASTEVENTS:<control signals>,<min>,<max>,<min2>,<max2)]`  
 Where `<control signals>` field may contain controls signal letters (`H`, `S` etc.) and the rest axis letters for the corresponding limit switches inputs.
-* More settings susbsystem changes and refactored $-system commands parser.  
+* More settings subsystem changes and refactored $-system commands parser.  
 There are some API changes related to this that may affect user defined plugins.
 * Added $7 setting for option "Spindle off with zero speed".
 * Added `|FW:grblHAL` element to full real-time report requested by sending `0x87`. 
@@ -1042,8 +1042,8 @@ Currently only the iMXRT1062 \(Teensy 4.x\) driver has support for this, for now
 __NOTE:__ A override will _not_ affect handling of homing and limit switch events elsewhere.
 * Now adds `ODO` to `NEWOPT` tag values if odometer data is available.
 * Updated _[my_plugin.c](templates/my_plugin.c)_ [template](templates/README.md) with settings details for `$HELP` and `$ES`/`$EG` enumerations.
-* Settings/setting groups handling enhanced, moved some to plugins and added sorting (requres enough heap).
-* Removed external dependecies by adding driver source/USB blob to LPC176x driver.
+* Settings/setting groups handling enhanced, moved some to plugins and added sorting (requires enough heap).
+* Removed external dependencies by adding driver source/USB blob to LPC176x driver.
 * Enhanced and improved ModBus support code for VFD spindle, added settings for baud rate and receive timeout.
 * Added support for enumeration of and help for driver and plugin provided settings and setting groups.
 * Moved board selection etc. to [CMakeLists.txt](drivers/ESP32/CMakeLists.txt) for [ESP32 driver](drivers/ESP32/README.md) for simpler configuration.
@@ -1132,7 +1132,7 @@ Build 20200923:
 * Initial changes to ESP32 driver to allow compilation with PlatformIO, added my_machine.h for this. Note that my_machine.h is not used if compiling with idf.py.
 * Added home position to `$#` ngc report, e.g. `[HOME,0.000,0.000,0.000:7]` - means all axes are homed. Position is reported in machine coordinates. `:7` in the example is an axis bitfield, the reported value is for which axes are homed: bit 0 is Z, 1 is X etc. `:0` = no axes homed.
 * "Hardened" the new tool change functionality even more. Initial changes for multi-axis tool reference offset made.  
-An empy message will now be sent when tool change is complete, this to clear any tool change related message in the sender.
+An empty message will now be sent when tool change is complete, this to clear any tool change related message in the sender.
 * Added call to [weak](https://en.wikipedia.org/wiki/Weak_symbol) `my_plugin_init()` function at startup, name your [plugin](https://github.com/terjeio/grblHAL/tree/master/plugins) init function `void my_plugin_init (void)` and there is no need to change any grblHAL source files to bring it alive.  
 Use this feature for your private plugin only, multiple public plugins using this name cannot coexist!
 * Some changes to improve code readability and added strict check for `G59.x` gcodes.
@@ -1210,7 +1210,7 @@ Build 20200722:
 * New plugin for [quadrature encoder input](https://github.com/terjeio/grblHAL/issues/73#issuecomment-659222664) for up to 5 encoders \(driver dependent\). Can be used to adjust overrides and has rudimentary support for MPG functionality. Work in progress and the iMXRT1062 \(Teensy 4\) driver is currently the only driver with low-level support for this (one encoder).
 * New plugin for [ModBus VFD](https://github.com/terjeio/grblHAL/issues/68) spindle controllers. Untested and with limited driver support in this build.
 * Added setting, `$340` for spindle at speed tolerance \(percent\). If spindle fails to reach speed within limits in 4 seconds alarm 14 will be raised. Set to 0 to disable. Availability driver dependent.
-* All [new settings](https://github.com/terjeio/grblHAL/wiki/Additional-or-extended-settings) are now possibly to set independent of the [compatibility level](https://github.com/terjeio/grblHAL/wiki/Changes-from-grbl-1.1#workaround) except some settings that has flags added to them. The added flags will not be available at all compatibilty levels. A new command, `$+`, can be used to list all settings independent of compatibilty level.
+* All [new settings](https://github.com/terjeio/grblHAL/wiki/Additional-or-extended-settings) are now possibly to set independent of the [compatibility level](https://github.com/terjeio/grblHAL/wiki/Changes-from-grbl-1.1#workaround) except some settings that has flags added to them. The added flags will not be available at all compatibility levels. A new command, `$+`, can be used to list all settings independent of compatibility level.
 * Internal changes to settings data in order to simplify automatic migration on changes. Automatic migration is on the roadmap.
 
 <sup>1</sup> Note that several factors may affect the accuracy of these settings such as step output mode, number of axes defined and compiler optimization settings.
@@ -1276,5 +1276,5 @@ G76 threading support added to grblHAL in combination with the [MSP432 driver](d
 
 **WARNING!** This is a potentially dangerous addition. Do NOT use if you do not understand the risks. A proper E-Stop is a must, it should cut power to the steppers and if possible engage any spindle brake. The implementation is based on the [linuxcnc specification](http://linuxcnc.org/docs/2.6/html/gcode/gcode.html#sec:G76-Threading-Canned). Please note that I am not a machinist so my interpretation and implementation may be wrong!
 
-G76 availablity requires a spindle encoder with index pulse, grblHAL configured to [lathe mode](doc/markdown/settings.md#opmode) and tuning of the spindle sync PID loop.  
+G76 availability requires a spindle encoder with index pulse, grblHAL configured to [lathe mode](doc/markdown/settings.md#opmode) and tuning of the spindle sync PID loop.  
 __NOTE:__ Feed hold is delayed until spindle synced cut is complete, spindle RPM overrides and CSS mode disabled through the whole cycle. 

--- a/config.h
+++ b/config.h
@@ -121,7 +121,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 // the associated data is refreshed and included in the status report. However, if one of these value
 // changes, Grbl will automatically include this data in the next status report, regardless of what the
 // count is at the time. This helps reduce the communication overhead involved with high frequency reporting
-// and agressive streaming. There is also a busy and an idle refresh count, which sets up Grbl to send
+// and aggressive streaming. There is also a busy and an idle refresh count, which sets up Grbl to send
 // refreshes more often when its not doing anything important. With a good GUI, this data doesn't need
 // to be refreshed very often, on the order of a several seconds.
 // NOTE: WCO refresh must be 2 or greater. OVERRIDE refresh must be 1 or greater.
@@ -253,7 +253,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 // Defines the non-volatile data restored upon a settings version change and `$RST=*` command. Whenever the
 // the settings or other non-volatile data structure changes between Grbl versions, Grbl will automatically
 // wipe and restore the non-volatile data. These macros controls what data is wiped and restored. This is useful
-// particularily for OEMs that need to retain certain data. For example, the BUILD_INFO string can be
+// particularly for OEMs that need to retain certain data. For example, the BUILD_INFO string can be
 // written into non-volatile storage via a separate program to contain product data. Altering these
 // macros to not restore the build info non-volatile storage will ensure this data is retained after firmware upgrades.
 //#define SETTINGS_RESTORE_DEFAULTS          0 // Default enabled, uncomment to disable
@@ -267,7 +267,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 // to prevent this data from being over-written by a user, when used to store OEM product data.
 // NOTE: If disabled and to ensure Grbl can never alter the build info line, you'll also need to enable
 // the SETTING_RESTORE_ALL macro above and remove SETTINGS_RESTORE_BUILD_INFO from the mask.
-// NOTE: See the included grblWrite_BuildInfo.ino example file to write this string seperately.
+// NOTE: See the included grblWrite_BuildInfo.ino example file to write this string separately.
 //#define DISABLE_BUILD_INFO_WRITE_COMMAND // '$I=' Default enabled. Uncomment to disable.
 
 // Enables and configures Grbl's sleep mode feature. If the spindle or coolant are powered and Grbl
@@ -293,14 +293,14 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 
 // When the HAL driver supports spindle sync then this option sets the number of pulses per revolution
 // for the spindle encoder. Depending on the driver this may lead to the "spindle at speed" detection
-// beeing enabled. When this is enabled grbl will wait for the spindle to reach the programmed speed
+// being enabled. When this is enabled grbl will wait for the spindle to reach the programmed speed
 // before continue processing. NOTE: Currently there is no timeout for this wait.
 // Default value is 0, meaning spindle sync is disabled
 //#define DEFAULT_SPINDLE_PPR 0 // Pulses per revolution. Default 0.
 
 // This option will automatically disable the laser during a feed hold by invoking a spindle stop
 // override immediately after coming to a stop. However, this also means that the laser still may
-// be reenabled by disabling the spindle stop override, if needed. This is purely a safety feature
+// be re-enabled by disabling the spindle stop override, if needed. This is purely a safety feature
 // to ensure the laser doesn't inadvertently remain powered while at a stop and cause a fire.
 //#define DEFAULT_ENABLE_LASER_DURING_HOLD // Default enabled. Uncomment to disable.
 
@@ -486,7 +486,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 //#define DISABLE_G92_PERSISTENCE 0
 
 #if COMPATIBILITY_LEVEL == 0
-// Number of tools in tool table, uncomment and edit if neccesary to enable (max. 16 allowed)
+// Number of tools in tool table, uncomment and edit if necessary to enable (max. 16 allowed)
 //#define N_TOOLS 8
 #endif
 
@@ -591,7 +591,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 // cycle, but this requires some pin settings changes in cpu_map.h file. For example, the default homing
 // cycle can share the Z limit pin with either X or Y limit pins, since they are on different cycles.
 // By sharing a pin, this frees up a precious IO pin for other purposes. In theory, all axes limit pins
-// may be reduced to one pin, if all axes are homed with seperate cycles, or vice versa, all three axes
+// may be reduced to one pin, if all axes are homed with separate cycles, or vice versa, all three axes
 // on separate pin, but homed in one cycle. Also, it should be noted that the function of hard limits
 // will not be affected by pin sharing.
 // NOTE: Defaults are set for a traditional 3-axis CNC machine. Z-axis first to clear, followed by X & Y.

--- a/gcode.c
+++ b/gcode.c
@@ -434,7 +434,7 @@ char *gc_normalize_block (char *block, char **message)
                 break;
 
             case '(':
-                // TODO: generate error if a left paranthesis is found inside a comment...
+                // TODO: generate error if a left parenthesis is found inside a comment...
                 comment = s1;
                 break;
 
@@ -724,7 +724,7 @@ status_code_t gc_execute_block(char *block)
         // NOTE: Mantissa is multiplied by 100 to catch non-integer command values. This is more
         // accurate than the NIST gcode requirement of x10 when used for commands, but not quite
         // accurate enough for value words that require integers to within 0.0001. This should be
-        // a good enough comprimise and catch most all non-integer errors. To make it compliant,
+        // a good enough compromise and catch most all non-integer errors. To make it compliant,
         // we would simply need to change the mantissa to int16, but this add compiled flash space.
         // Maybe update this later.
         if(isnan(value))
@@ -1911,7 +1911,7 @@ status_code_t gc_execute_block(char *block)
                 case NonModal_GoHome_0: // G28
                 case NonModal_GoHome_1: // G30
                     // [G28/30 Errors]: Cutter compensation is enabled.
-                    // Retreive G28/30 go-home position data (in machine coordinates) from non-volatile storage
+                    // Retrieve G28/30 go-home position data (in machine coordinates) from non-volatile storage
 
                     if (!settings_read_coord_data(gc_block.non_modal_command == NonModal_GoHome_0 ? CoordinateSystem_G28 : CoordinateSystem_G30, &gc_block.values.coord_data.xyz))
                         FAIL(Status_SettingReadFail);

--- a/gcode.h
+++ b/gcode.h
@@ -32,7 +32,7 @@
 // Define command actions for within execution-type modal groups (motion, stopping, non-modal). Used
 // internally by the parser to know which command to execute.
 // NOTE: Some values are assigned specific values to make g-code state reporting and parsing
-// compile a litte smaller. Although not
+// compile a little smaller. Although not
 // ideal, just be careful with values that state 'do not alter' and check both report.c and gcode.c
 // to see how they are used, if you need to alter them.
 

--- a/grbl.h
+++ b/grbl.h
@@ -99,7 +99,7 @@
 // NOTE: If changed, manually update help message in report.c.
 
 #define CMD_EXIT 0x03 // ctrl-C (ETX)
-#define CMD_REBOOT 0x14 // ctrl-T (DC4) - only acted upon if preceeded by 0x1B (ESC)
+#define CMD_REBOOT 0x14 // ctrl-T (DC4) - only acted upon if preceded by 0x1B (ESC)
 #define CMD_RESET 0x18 // ctrl-X (CAN)
 #define CMD_STOP 0x19 // ctrl-Y (EM)
 #define CMD_STATUS_REPORT_LEGACY '?'
@@ -110,7 +110,7 @@
 // NOTE: All override realtime commands must be in the extended ASCII character set, starting
 // at character value 128 (0x80) and up to 255 (0xFF). If the normal set of realtime commands,
 // such as status reports, feed hold, reset, and cycle start, are moved to the extended set
-// space, protocol.c's protocol_process_realtime() will need to be modified to accomodate the change.
+// space, protocol.c's protocol_process_realtime() will need to be modified to accommodate the change.
 #define CMD_STATUS_REPORT 0x80 // TODO: use 0x05 ctrl-E ENQ instead?
 #define CMD_CYCLE_START 0x81   // TODO: use 0x06 ctrl-F ACK instead? or SYN/DC2/DC3?
 #define CMD_FEED_HOLD 0x82     // TODO: use 0x15 ctrl-U NAK instead?
@@ -199,7 +199,7 @@
 // the associated data is refreshed and included in the status report. However, if one of these value
 // changes, Grbl will automatically include this data in the next status report, regardless of what the
 // count is at the time. This helps reduce the communication overhead involved with high frequency reporting
-// and agressive streaming. There is also a busy and an idle refresh count, which sets up Grbl to send
+// and aggressive streaming. There is also a busy and an idle refresh count, which sets up Grbl to send
 // refreshes more often when its not doing anything important. With a good GUI, this data doesn't need
 // to be refreshed very often, on the order of a several seconds.
 // NOTE: WCO refresh must be 2 or greater. OVERRIDE refresh must be 1 or greater.

--- a/grbllib.c
+++ b/grbllib.c
@@ -264,7 +264,7 @@ int grbl_enter (void)
         if(!hal.driver_cap.atc)
             tc_init();
 
-        // Print welcome message. Indicates an initialization has occured at power-up or with a reset.
+        // Print welcome message. Indicates an initialization has occurred at power-up or with a reset.
         report_init_message();
 
         if(state_get() == STATE_ESTOP)

--- a/hal.h
+++ b/hal.h
@@ -266,7 +266,7 @@ typedef void (*stepper_cycles_per_tick_ptr)(uint32_t cycles_per_tick);
 For plain drivers the most of the information pointed to by the \a stepper argument can be ignored.
 The most used fields are these:
 <br>\ref stepper.step_outbits
-<br>\ref stepper.dir_outbits - these are only necessary to ouput to the drivers when \ref stepper.dir_change is true.
+<br>\ref stepper.dir_outbits - these are only necessary to output to the drivers when \ref stepper.dir_change is true.
 
 If the driver is to support spindle synced motion many more needs to be referenced...
 
@@ -494,7 +494,7 @@ typedef struct {
     /*! \brief Driver setup handler.
     Called once by the core after settings has been loaded. The driver should enable MCU peripherals in the provided function.
     \param settings pointer to settings_t structure.
-    \returns true if completed sucessfully and the driver supports the _settings->version_ number, false otherwise.
+    \returns true if completed successfully and the driver supports the _settings->version_ number, false otherwise.
     */
     driver_setup_ptr driver_setup;
 
@@ -596,7 +596,7 @@ Then _hal.driver_setup()_ will be called so that the driver can configure the re
 
 __NOTE__: This is the only driver function that is called directly from the core, all others are called via HAL function pointers.
 
-\returns true if completed sucessfully and the driver matches the _hal.version number_, false otherwise.
+\returns true if completed successfully and the driver matches the _hal.version number_, false otherwise.
 */
 extern bool driver_init (void);
 

--- a/ioports.c
+++ b/ioports.c
@@ -23,7 +23,7 @@
  * @file
  *
  * Some wrapper functions for the #io_port_t API.
- * They perform the neccesary checks for both availablity of ports
+ * They perform the necessary checks for both availability of ports
  * and advanced functionality simplifying plugin code that uses them.
  */
 

--- a/ioports.h
+++ b/ioports.h
@@ -1,5 +1,5 @@
 /*
-  ioports.h - typedefs, API structure and functions for auxillary I/O
+  ioports.h - typedefs, API structure and functions for auxiliary I/O
 
   Part of grblHAL
 
@@ -33,7 +33,7 @@ typedef enum {
 
 /*! \brief Pointer to function for setting a digital output.
 \param port port number
-\param on true to set ouput high, false to set it low
+\param on true to set output high, false to set it low
 */
 typedef void (*digital_out_ptr)(uint8_t port, bool on);
 
@@ -103,7 +103,7 @@ typedef void (*ioport_interrupt_callback_ptr)(uint8_t port, bool state);
 */
 typedef bool (*ioport_register_interrupt_handler_ptr)(uint8_t port, pin_irq_mode_t irq_mode, ioport_interrupt_callback_ptr interrupt_callback);
 
-//! Properties and handlers for auxillary digital and analog I/O.
+//! Properties and handlers for auxiliary digital and analog I/O.
 typedef struct {
     uint8_t num_digital_in;                         //!< Number of digital inputs available.
     uint8_t num_digital_out;                        //!< Number of digital outputs available.
@@ -112,9 +112,9 @@ typedef struct {
     digital_out_ptr digital_out;                    //!< Optional handler for setting a digital output.
     analog_out_ptr analog_out;                      //!< Optional handler for setting an analog output.
     wait_on_input_ptr wait_on_input;                //!< Optional handler for reading a digital or analog input.
-    set_pin_description_ptr set_pin_description;    //!< Optional handler for setting a description of an auxillary pin.
-    get_pin_info_ptr get_pin_info;                  //!< Optional handler for getting information about an auxillary pin.
-    claim_port_ptr claim;                           //!< Optional handler for claiming an auxillary pin for exclusive use.
+    set_pin_description_ptr set_pin_description;    //!< Optional handler for setting a description of an auxiliary pin.
+    get_pin_info_ptr get_pin_info;                  //!< Optional handler for getting information about an auxiliary pin.
+    claim_port_ptr claim;                           //!< Optional handler for claiming an auxiliary pin for exclusive use.
     swap_pins_ptr swap_pins;                        //!< Optional handler for swapping pins.
     ioport_register_interrupt_handler_ptr register_interrupt_handler;
 } io_port_t;

--- a/limits.c
+++ b/limits.c
@@ -68,7 +68,7 @@ ISR_CODE axes_signals_t ISR_FUNC(limit_signals_merge)(limit_signals_t signals)
     return state;
 }
 
-// Merge (bitwise or) home switch inputs (typically aquired from limits.min and limits.min2).
+// Merge (bitwise or) home switch inputs (typically acquired from limits.min and limits.min2).
 ISR_CODE static axes_signals_t ISR_FUNC(homing_signals_select)(limit_signals_t signals, axes_signals_t auto_square, squaring_mode_t mode)
 {
     axes_signals_t state;

--- a/maslow.h
+++ b/maslow.h
@@ -39,7 +39,7 @@
 #define MAX_SEG_LENGTH_MM 2.0f /* long lines must be segmented due to circular motion */
 
   // PID position loop factors              X: Kp = 25000 Ki = 15000 Kd = 22000 Imax = 5000
-  // 14.000 fixed point arithmatic S13.10
+  // 14.000 fixed point arithmetic S13.10
 #ifdef DRIVER_TLE5206
     #define MASLOW_A_KP     10.0f
     #define MASLOW_A_KI     21.0f

--- a/motion_control.c
+++ b/motion_control.c
@@ -89,7 +89,7 @@ void mc_sync_backlash_position (void)
 // unless invert_feed_rate is true. Then the feed_rate means that the motion should be completed in
 // (1 minute)/feed_rate time.
 // NOTE: This is the primary gateway to the grbl planner. All line motions, including arc line
-// segments, must pass through this routine before being passed to the planner. The seperation of
+// segments, must pass through this routine before being passed to the planner. The separation of
 // mc_line and plan_buffer_line is done primarily to place non-planner-type functions from being
 // in the planner and to let backlash compensation or canned cycle integration simple and direct.
 bool mc_line (float *target, plan_line_data_t *pl_data)

--- a/planner.h
+++ b/planner.h
@@ -117,7 +117,7 @@ void plan_reset(); // Reset all
 bool plan_buffer_line(float *target, plan_line_data_t *pl_data);
 
 // Called when the current block is no longer needed. Discards the block and makes the memory
-// availible for new blocks.
+// available for new blocks.
 void plan_discard_current_block();
 
 // Gets the planner block for the special system motion cases. (Parking/Homing)

--- a/plugins_init.h
+++ b/plugins_init.h
@@ -1,7 +1,7 @@
 /*
   plugins_init.h - An embedded CNC Controller with rs274/ngc (g-code) support
 
-  Calls the init function of enabled plugins, may be included at the end of the drivers driver_init() inmplementation.
+  Calls the init function of enabled plugins, may be included at the end of the drivers driver_init() implementation.
 
   These are NOT referenced in the core grbl code
 

--- a/report.c
+++ b/report.c
@@ -25,7 +25,7 @@
   as the protocol status messages, feedback messages, and status reports, are stored here.
   For the most part, these functions primarily are called from protocol.c methods. If a
   different style feedback is desired (i.e. JSON), then a user can change these following
-  methods to accomodate their needs.
+  methods to accommodate their needs.
 */
 
 #include <math.h>

--- a/sleep.c
+++ b/sleep.c
@@ -30,7 +30,7 @@ static void fall_asleep()
     slumber = false;
 }
 
-// Starts sleep timer if running conditions are satified. When elapsed, sleep mode is executed.
+// Starts sleep timer if running conditions are satisfied. When elapsed, sleep mode is executed.
 static void sleep_execute()
 {
     // Enable sleep timeout

--- a/spindle_sync.h
+++ b/spindle_sync.h
@@ -1,7 +1,7 @@
 /*
   spindle_sync.h - An embedded CNC Controller with rs274/ngc (g-code) support
 
-  Spindle sync data strucures
+  Spindle sync data structures
 
   NOTE: not referenced in the core grbl code
 
@@ -66,7 +66,7 @@ typedef struct {
     float steps_per_mm;             // Steps per mm for current block
     float programmed_rate;          // Programmed feed in mm/rev for current block
     int32_t min_cycles_per_tick;    // Minimum cycles per tick for PID loop
-    uint_fast8_t segment_id;        // Used for detecing start of new segment
+    uint_fast8_t segment_id;        // Used for detecting start of new segment
     pidf_t pid;                     // PID data for position
     stepper_pulse_start_ptr stepper_pulse_start_normal; // Driver pulse function to restore after spindle sync move is completed
 #ifdef PID_LOG

--- a/stepper.c
+++ b/stepper.c
@@ -92,7 +92,7 @@ static amass_t amass;
 // Message to be output by foreground process
 static char *message = NULL; // TODO: do we need a queue for this?
 
-// Used for blocking new segments beeing added to the seqment buffer until deceleration starts
+// Used for blocking new segments being added to the seqment buffer until deceleration starts
 // after probe signal has been asserted.
 static volatile bool probe_asserted = false;
 
@@ -253,7 +253,7 @@ ISR_CODE void ISR_FUNC(st_go_idle)(void)
    AMASS artificially increases the Bresenham resolution without effecting the algorithm's
    innate exactness. AMASS adapts its resolution levels automatically depending on the step
    frequency to be executed, meaning that for even lower step frequencies the step smoothing
-   level increases. Algorithmically, AMASS is acheived by a simple bit-shifting of the Bresenham
+   level increases. Algorithmically, AMASS is achieved by a simple bit-shifting of the Bresenham
    step count for each AMASS level. For example, for a Level 1 step smoothing, we bit shift
    the Bresenham step event count, effectively multiplying it by 2, while the axis step counts
    remain the same, and then double the stepper ISR frequency. In effect, we are allowing the
@@ -331,7 +331,7 @@ ISR_CODE void ISR_FUNC(stepper_driver_interrupt_handler)(void)
                 if(st.exec_block->overrides.sync)
                     sys.override.control = st.exec_block->overrides;
 
-                // Execute output commands to be syncronized with motion
+                // Execute output commands to be synchronized with motion
                 while(st.exec_block->output_commands) {
                     output_command_t *cmd = st.exec_block->output_commands;
                     cmd->is_executed = true;

--- a/stepper.h
+++ b/stepper.h
@@ -105,7 +105,7 @@ typedef struct stepper {
     uint_fast16_t step_count;       //!< Steps remaining in line segment motion.
     uint32_t step_event_count;      //!< Number of step pulse events to be output by this segment.
     st_block_t *exec_block;         //!< Pointer to the block data for the segment being executed.
-    segment_t *exec_segment;        //!< Pointer to the segment beeing executed.
+    segment_t *exec_segment;        //!< Pointer to the segment being executed.
 } stepper_t;
 
 // Initialize and setup the stepper motor subsystem

--- a/stream.h
+++ b/stream.h
@@ -127,7 +127,7 @@ typedef bool (*enqueue_realtime_command_ptr)(char c);
 
 /*! \brief Optional, but recommended, pointer to function for enqueueing realtime command characters.
 \param c character to enqueue.
-\returns \a true if sucessfully enqueued, \a false otherwise.
+\returns \a true if successfully enqueued, \a false otherwise.
 
 __NOTE:__ Stream implementations should pass the character over the current handler registered by the set_enqueue_rt_handler().
 
@@ -169,7 +169,7 @@ This function is called with the _await_ parameter true on executing a tool chan
 The core function stream_rx_suspend() can be called with the _await_ parameter to do this,
 it will replace the _hal.stream.read_ handler with a pointer to the dummy function stream_get_null().
 
-Reading from the input is blocked until a tool change aknowledge character #CMD_TOOL_ACK is received,
+Reading from the input is blocked until a tool change acknowledge character #CMD_TOOL_ACK is received,
  when the driver receives this the input buffer is to be saved away and reading from the input resumed by
  restoring the _hal.stream.read_ handler with its own read character function.
 Driver code can do this by calling the core function stream_rx_backup().


### PR DESCRIPTION
Found via`codespell -q 3 -L iterm,nd`