### PR TITLE
Allow enqueuing gcode outside of normal input stream when in alarm state

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -68,8 +68,8 @@ static void protocol_execute_rt_commands (void);
 bool protocol_enqueue_gcode (char *gcode)
 {
     bool ok = xcommand[0] == '\0' &&
-               (state_get() == STATE_IDLE || (state_get() & (STATE_JOG|STATE_TOOL_CHANGE))) &&
-                 bit_isfalse(sys.rt_exec_state, EXEC_MOTION_CANCEL);
+               (state_get() == STATE_IDLE || state_get() == STATE_ALARM  ||
+                 (state_get() & (STATE_JOG|STATE_TOOL_CHANGE))) && bit_isfalse(sys.rt_exec_state, EXEC_MOTION_CANCEL);
 
     if(ok && gc_state.file_run)
         ok = gc_state.modal.program_flow != ProgramFlow_Running || strncmp((char *)gcode, "$J=", 3);


### PR DESCRIPTION
Adds STATE_ALARM to the valid states for allowing gcode from outside of the normal input stream. 
I've been using this to allow my panel plugin to unlock the controller from an alarm state (typically after starting the controller with motor power disabled).
