### PR TITLE
bug on single axis home

### DIFF
--- a/motion_control.c
+++ b/motion_control.c
@@ -888,7 +888,7 @@ status_code_t mc_homing_cycle (axes_signals_t cycle)
         // Perform homing routine. NOTE: Special motion case. Only system reset works.
 
         if (!home_all) // Perform homing cycle based on mask.
-            homed_status = !limits_go_home(cycle);
+            homed_status = limits_go_home(cycle);
         else {
 
             uint_fast8_t idx = 0;


### PR DESCRIPTION
When Using single axis home, after homing the status remains 'Home'. Inverting the logic resolves.