### PR TITLE
Allow driver to be considered ok even if only update_rpm is added

### DIFF
--- a/grbllib.c
+++ b/grbllib.c
@@ -260,7 +260,7 @@ int grbl_enter (void)
 
     if((driver.spindle = spindle_select(settings.spindle.flags.type))) {
         spindle_ptrs_t *spindle = spindle_get(0);
-        driver.spindle = spindle->get_pwm == NULL || spindle->update_pwm != NULL;
+        driver.spindle = spindle->get_pwm == NULL || spindle->update_pwm != NULL || spindle->update_rpm != NULL;
     } else
         driver.spindle = spindle_select(spindle_add_null());
 


### PR DESCRIPTION
Not sure if this is correct, but the simulator for example only initializes update_rpm with certain flag settings.
There seem to be places where update_pwm and update_rpm are checked independently @terjeio?