### PR TITLE
Enable parameter substitution in MSG comments

### DIFF
--- a/gcode.c
+++ b/gcode.c
@@ -548,6 +548,51 @@ bool gc_modal_state_restore (gc_modal_t *copy)
 
 #endif // NGC_PARAMETERS_ENABLE
 
+void substitute_parameters(char *comment, char **message) {
+    size_t len = 0;
+    float value;
+    char *s3;
+    uint_fast8_t char_counter = 0;
+    char c = *(comment + char_counter);
+
+    // Trim leading spaces
+    while(*comment == ' ')
+        comment++;
+
+    // Calculate length of substituted string
+    while((c = comment[char_counter++])) {
+        if(c == '#') {
+            char_counter--;
+            if(read_parameter(comment, &char_counter, &value) == Status_OK)
+                len += strlen(trim_float(ftoa(value, ngc_float_decimals())));
+            else
+                len += 3; // "N/A"
+        } else
+            len++;
+    }
+
+    // Perform substitution
+    if((s3 = *message = malloc(len + 1))) {
+
+        *s3 = '\0';
+        char_counter = 0;
+
+        while((c = comment[char_counter++])) {
+            if(c == '#') {
+                char_counter--;
+                if(read_parameter(comment, &char_counter, &value) == Status_OK)
+                    strcat(s3, trim_float(ftoa(value, ngc_float_decimals())));
+                else
+                    strcat(s3, "N/A");
+                s3 = strchr(s3, '\0');
+            } else {
+                *s3++ = c;
+                *s3 = '\0';
+            }
+        }
+    }
+}
+
 // Remove whitespace, control characters, comments and if block delete is active block delete lines
 // else the block delete character. Remaining characters are converted to upper case.
 // If the driver handles message comments then the first is extracted and returned in a dynamically
@@ -597,47 +642,7 @@ char *gc_normalize_block (char *block, char **message)
                         if(message && *message == NULL && !strncmp(comment, "(MSG,", 5) && (*message = malloc(len))) {
                             comment += 5;
 #if NGC_PARAMETERS_ENABLE
-                            len = 0;
-                            float value;
-                            char *s3;
-                            uint_fast8_t char_counter = 0;
-
-                            // Trim leading spaces
-                            while(*comment == ' ')
-                                comment++;
-
-                            // Calculate length of substituted string
-                            while((c = comment[char_counter++])) {
-                                if(c == '#') {
-                                    char_counter--;
-                                    if(read_parameter(comment, &char_counter, &value) == Status_OK)
-                                        len += strlen(trim_float(ftoa(value, ngc_float_decimals())));
-                                    else
-                                        len += 3; // "N/A"
-                                } else
-                                    len++;
-                            }
-
-                            // Perform substitution
-                            if((s3 = *message = malloc(len + 1))) {
-
-                                *s3 = '\0';
-                                char_counter = 0;
-
-                                while((c = comment[char_counter++])) {
-                                    if(c == '#') {
-                                        char_counter--;
-                                        if(read_parameter(comment, &char_counter, &value) == Status_OK)
-                                            strcat(s3, trim_float(ftoa(value, ngc_float_decimals())));
-                                        else
-                                            strcat(s3, "N/A");
-                                        s3 = strchr(s3, '\0');
-                                    } else {
-                                        *s3++ = c;
-                                        *s3 = '\0';
-                                    }
-                                }
-                            }
+                            substitute_parameters(comment, message);
 #else
                             while(*comment == ' ') {
                                 comment++;
@@ -652,50 +657,8 @@ char *gc_normalize_block (char *block, char **message)
                         if(message && *message == NULL && !strncmp(comment, "(DEBUG,", 7)) {
 
                             if(settings.flags.ngc_debug_out) {
-
-                                float value;
-                                char *s3;
-                                uint_fast8_t char_counter = 0;
-
-                                len = 0;
                                 comment += 7;
-
-                                // Trim leading spaces
-                                while(*comment == ' ')
-                                    comment++;
-
-                                // Calculate length of substituted string
-                                while((c = comment[char_counter++])) {
-                                    if(c == '#') {
-                                        char_counter--;
-                                        if(read_parameter(comment, &char_counter, &value) == Status_OK)
-                                            len += strlen(trim_float(ftoa(value, ngc_float_decimals())));
-                                        else
-                                            len += 3; // "N/A"
-                                    } else
-                                        len++;
-                                }
-
-                                // Perform substitution
-                                if((s3 = *message = malloc(len + 1))) {
-
-                                    *s3 = '\0';
-                                    char_counter = 0;
-
-                                    while((c = comment[char_counter++])) {
-                                        if(c == '#') {
-                                            char_counter--;
-                                            if(read_parameter(comment, &char_counter, &value) == Status_OK)
-                                                strcat(s3, trim_float(ftoa(value, ngc_float_decimals())));
-                                            else
-                                                strcat(s3, "N/A");
-                                            s3 = strchr(s3, '\0');
-                                        } else {
-                                            *s3++ = c;
-                                            *s3 = '\0';
-                                        }
-                                    }
-                                }
+                                substitute_parameters(comment, message);
                             }
 
                             *comment = '\0'; // Do not generate grbl.on_gcode_comment event!

--- a/gcode.c
+++ b/gcode.c
@@ -595,12 +595,12 @@ char *gc_normalize_block (char *block, char **message)
                         size_t len = s1 - comment - 4;
 
                         if(message && *message == NULL && !strncmp(comment, "(MSG,", 5) && (*message = malloc(len))) {
+                            comment += 5;
+#if NGC_PARAMETERS_ENABLE
+                            len = 0;
                             float value;
                             char *s3;
                             uint_fast8_t char_counter = 0;
-
-                            len = 0;
-                            comment += 5;
 
                             // Trim leading spaces
                             while(*comment == ' ')
@@ -638,6 +638,13 @@ char *gc_normalize_block (char *block, char **message)
                                     }
                                 }
                             }
+#else
+                            while(*comment == ' ') {
+                                comment++;
+                                len--;
+                            }
+                            memcpy(*message, comment, len);
+#endif
                         }
 
 #if NGC_EXPRESSIONS_ENABLE


### PR DESCRIPTION
In many cases it is necessary to communicate something to an operator which contains a dynamic value, and being able to use the MSG comments for this seems natural.

The reason for not using DEBUG comments is that those are used for debugging, and create a lot of noise for the operator. So the operator should be able to disable DEBUG output and still get the messages they need

Example output with debug output enabled:
```
G65P200T2 
[MSG:Find pickup]
[MSG:Slot 0: 2 T:2]
[MSG:Returning 0]
[MSG:Tool T2 already stored in slot 1 from the back]
```

Example output with debug output disabled:
```
G65P200T2
[MSG:Put tool T2 in slot 1 from the back]
```

P200 is a macro that finds an available slot in my tool rack, tells the operator to put it there, and assigns the tool to the slot so that it knows where to find it.