### PR TITLE
Allow return without expression

### DIFF
--- a/ngc_expr.c
+++ b/ngc_expr.c
@@ -716,7 +716,7 @@ other readers, depending upon the first character.
 \param value pointer to float where result is to be stored.
 \returns #Status_OK enum value if processed without error, appropriate \ref status_code_t enum value if not.
 */
-static status_code_t read_real_value (char *line, uint_fast8_t *pos, float *value)
+status_code_t read_real_value (char *line, uint_fast8_t *pos, float *value)
 {
     char c = line[*pos], c1;
 

--- a/ngc_expr.h
+++ b/ngc_expr.h
@@ -4,5 +4,5 @@
 #define _NGC_EXPR_H_
 
 status_code_t ngc_eval_expression (char *line, uint_fast8_t *pos, float *value);
-
+status_code_t read_real_value (char *line, uint_fast8_t *pos, float *value);
 #endif

--- a/ngc_flowctrl.c
+++ b/ngc_flowctrl.c
@@ -577,7 +577,7 @@ status_code_t ngc_flowctrl (uint32_t o_label, char *line, uint_fast8_t *pos, boo
                     else if((g65_return = !!grbl.on_macro_return))
                         ngc_flowctrl_unwind_stack(stack[stack_idx].file);
 
-                    if(ngc_eval_expression(line, pos, &value) == Status_OK) {
+                    if(read_real_value(line, pos, &value) == Status_OK) {
                         ngc_named_param_set("_value", value);
                         ngc_named_param_set("_value_returned", 1.0f);
                     } else

--- a/ngc_flowctrl.c
+++ b/ngc_flowctrl.c
@@ -580,8 +580,10 @@ status_code_t ngc_flowctrl (uint32_t o_label, char *line, uint_fast8_t *pos, boo
                     if(read_real_value(line, pos, &value) == Status_OK) {
                         ngc_named_param_set("_value", value);
                         ngc_named_param_set("_value_returned", 1.0f);
-                    } else
+                    } else {
+                        ngc_named_param_set("_value", 0.0f);
                         ngc_named_param_set("_value_returned", 0.0f);
+                    }
 
                     if(g65_return)
                         grbl.on_macro_return();


### PR DESCRIPTION
Small change to allow writing `return #5070` instead of `return [#5070]` and similar.
Still allows the old way of returning only using expressions, but I find this syntax less error-prone.

Also explicitly setting `_value` to 0 if no value is returned, as I have had some confusion where I get a unexpected `_value` but `_value_returned` is 0 😅 