### PR TITLE
Add Setting for Axis Limitpos

### DIFF
--- a/config.h
+++ b/config.h
@@ -39,7 +39,7 @@ specific needs, i.e. performance tuning or adjusting to non-typical machines.
 If more than 3 axes are configured a compliant driver and board map file is needed.
  */
 #ifndef N_AXIS
-#define N_AXIS 3 // Number of axes
+#define N_AXIS 4 // Number of axes
 #endif
 
 /*! \def AXIS_REMAP_ABC2UVW
@@ -498,7 +498,7 @@ by a driver or a plugin.
 #endif
 
 #if !defined ENABLE_BACKLASH_COMPENSATION || defined __DOXYGEN__
-#define ENABLE_BACKLASH_COMPENSATION Off
+#define ENABLE_BACKLASH_COMPENSATION On
 #endif
 
 #if COMPATIBILITY_LEVEL == 0 || defined __DOXYGEN__

--- a/machine_limits.c
+++ b/machine_limits.c
@@ -129,8 +129,10 @@ void limits_set_work_envelope (void)
                     sys.work_envelope.max.values[idx] = - (settings.axis[idx].max_travel + pulloff);
                 }
             } else {
-                sys.work_envelope.min.values[idx] = settings.axis[idx].max_travel + pulloff;
-                sys.work_envelope.max.values[idx] = - pulloff;
+                  sys.work_envelope.min.values[idx] = 0.0f;
+                  sys.work_envelope.max.values[idx] = settings.axis[idx].limit_pos - pulloff;;
+                //sys.work_envelope.min.values[idx] = settings.axis[idx].max_travel + pulloff;
+                //sys.work_envelope.max.values[idx] = - pulloff;
             }
         } else
             sys.work_envelope.min.values[idx] = sys.work_envelope.max.values[idx] = 0.0f;
@@ -155,9 +157,12 @@ void limits_set_machine_positions (axes_signals_t cycle, bool add_pulloff)
         } while(idx);
     } else do {
         if (cycle.mask & bit(--idx)) {
-            sys.home_position[idx] = bit_istrue(settings.homing.dir_mask.value, bit(idx))
-                                      ? settings.axis[idx].max_travel + pulloff
-                                      : - pulloff;
+            
+           // sys.position[idx] = settings.axis[idx].limit_pos - pulloff;
+            sys.home_position[idx] = settings.axis[idx].limit_pos - pulloff;
+            //sys.home_position[idx] = bit_istrue(settings.homing.dir_mask.value, bit(idx))
+            //                          ? settings.axis[idx].max_travel + pulloff
+            //                          : - pulloff;
             sys.position[idx] = lroundf(sys.home_position[idx] * settings.axis[idx].steps_per_mm);
         }
     } while(idx);

--- a/settings.c
+++ b/settings.c
@@ -210,6 +210,7 @@ PROGMEM const settings_t defaults = {
     .axis[X_AXIS].acceleration = (DEFAULT_X_ACCELERATION * 60.0f * 60.0f),
     .axis[X_AXIS].max_travel = (-DEFAULT_X_MAX_TRAVEL),
     .axis[X_AXIS].dual_axis_offset = 0.0f,
+    .axis[X_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[X_AXIS].backlash = 0.0f,
 #endif
@@ -219,6 +220,7 @@ PROGMEM const settings_t defaults = {
     .axis[Y_AXIS].max_travel = (-DEFAULT_Y_MAX_TRAVEL),
     .axis[Y_AXIS].acceleration = (DEFAULT_Y_ACCELERATION * 60.0f * 60.0f),
     .axis[Y_AXIS].dual_axis_offset = 0.0f,
+    .axis[Y_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[Y_AXIS].backlash = 0.0f,
 #endif
@@ -228,6 +230,7 @@ PROGMEM const settings_t defaults = {
     .axis[Z_AXIS].acceleration = (DEFAULT_Z_ACCELERATION * 60.0f * 60.0f),
     .axis[Z_AXIS].max_travel = (-DEFAULT_Z_MAX_TRAVEL),
     .axis[Z_AXIS].dual_axis_offset = 0.0f,
+    .axis[Z_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[Z_AXIS].backlash = 0.0f,
 #endif
@@ -238,6 +241,7 @@ PROGMEM const settings_t defaults = {
     .axis[A_AXIS].acceleration =(DEFAULT_A_ACCELERATION * 60.0f * 60.0f),
     .axis[A_AXIS].max_travel = (-DEFAULT_A_MAX_TRAVEL),
     .axis[A_AXIS].dual_axis_offset = 0.0f,
+    .axis[A_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[A_AXIS].backlash = 0.0f,
 #endif
@@ -250,6 +254,7 @@ PROGMEM const settings_t defaults = {
     .axis[B_AXIS].acceleration = (DEFAULT_B_ACCELERATION * 60.0f * 60.0f),
     .axis[B_AXIS].max_travel = (-DEFAULT_B_MAX_TRAVEL),
     .axis[B_AXIS].dual_axis_offset = 0.0f,
+    .axis[B_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[B_AXIS].backlash = 0.0f,
 #endif
@@ -262,6 +267,7 @@ PROGMEM const settings_t defaults = {
     .axis[C_AXIS].max_rate = DEFAULT_C_MAX_RATE,
     .axis[C_AXIS].max_travel = (-DEFAULT_C_MAX_TRAVEL),
     .axis[C_AXIS].dual_axis_offset = 0.0f,
+    .axis[C_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[C_AXIS].backlash = 0.0f,
 #endif
@@ -274,6 +280,7 @@ PROGMEM const settings_t defaults = {
     .axis[U_AXIS].max_rate = DEFAULT_U_MAX_RATE,
     .axis[U_AXIS].max_travel = (-DEFAULT_U_MAX_TRAVEL),
     .axis[U_AXIS].dual_axis_offset = 0.0f,
+    .axis[U_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[U_AXIS].backlash = 0.0f,
 #endif
@@ -285,6 +292,7 @@ PROGMEM const settings_t defaults = {
     .axis[V_AXIS].max_rate = DEFAULT_V_MAX_RATE,
     .axis[V_AXIS].max_travel = (-DEFAULT_V_MAX_TRAVEL),
     .axis[V_AXIS].dual_axis_offset = 0.0f,
+    .axis[V_AXIS].limit_pos = 0.0f,
 #if ENABLE_BACKLASH_COMPENSATION
     .axis[V_AXIS].backlash = 0.0f,
 #endif
@@ -596,6 +604,7 @@ PROGMEM static const setting_detail_t setting_detail[] = {
      { Setting_AxisMaxRate, Group_Axis0, "-axis maximum rate", axis_rate, Format_Decimal, "#####0.000", NULL, NULL, Setting_IsLegacyFn, set_axis_setting, get_float, NULL, AXIS_OPTS },
      { Setting_AxisAcceleration, Group_Axis0, "-axis acceleration", axis_accel, Format_Decimal, "#####0.000", NULL, NULL, Setting_IsLegacyFn, set_axis_setting, get_float, NULL, AXIS_OPTS },
      { Setting_AxisMaxTravel, Group_Axis0, "-axis maximum travel", axis_dist, Format_Decimal, "#####0.000", NULL, NULL, Setting_IsLegacyFn, set_axis_setting, get_float, NULL, AXIS_OPTS },
+     { Setting_AxisLimitPos, Group_Axis0, "-axis limit pos", axis_dist, Format_Decimal, "#####0.000", NULL, NULL, Setting_IsLegacyFn, set_axis_setting, get_float, NULL, AXIS_OPTS },
 #if ENABLE_BACKLASH_COMPENSATION
      { Setting_AxisBacklash, Group_Axis0, "-axis backlash compensation", axis_dist, Format_Decimal, "#####0.000##", NULL, NULL, Setting_IsExtendedFn, set_axis_setting, get_float, NULL, AXIS_OPTS },
 #endif
@@ -773,6 +782,7 @@ PROGMEM static const setting_descr_t setting_descr[] = {
     { Setting_AxisMaxRate, "Maximum rate. Used as G0 rapid rate." },
     { Setting_AxisAcceleration, "Acceleration. Used for motion planning to not exceed motor torque and lose steps." },
     { Setting_AxisMaxTravel, "Maximum axis travel distance from homing switch. Determines valid machine space for soft-limits and homing search distances." },
+    { Setting_AxisLimitPos, "Limit Position" },
 #if ENABLE_BACKLASH_COMPENSATION
     { Setting_AxisBacklash, "Backlash distance to compensate for." },
 #endif
@@ -1394,7 +1404,7 @@ static const char *set_axis_setting_unit (setting_id_t setting_id, uint_fast8_t 
             unit = is_rotary ? "step/deg" : "step/mm";
             break;
 
-        case Setting_AxisMaxRate:
+        case Setting_AxisMaxRate:       
             unit = is_rotary ? "deg/min" : "mm/min";
             break;
 
@@ -1403,6 +1413,7 @@ static const char *set_axis_setting_unit (setting_id_t setting_id, uint_fast8_t 
             break;
 
         case Setting_AxisMaxTravel:
+        case Setting_AxisLimitPos:
         case Setting_AxisBacklash:
             unit = is_rotary ? "deg" : "mm";
             break;
@@ -1529,7 +1540,9 @@ static status_code_t set_axis_setting (setting_id_t setting, float value)
             }
             tmp_set_soft_limits();
             break;
-
+        case Setting_AxisLimitPos:
+           settings.axis[idx].limit_pos = value;
+        break;
         case Setting_AxisBacklash:
 #if ENABLE_BACKLASH_COMPENSATION
             if(settings.axis[idx].backlash != value) {
@@ -1583,7 +1596,9 @@ static float get_float (setting_id_t setting)
             case Setting_AxisMaxTravel:
                 value = -settings.axis[idx].max_travel; // Store as negative for grbl internal use.
                 break;
-
+            case Setting_AxisLimitPos:
+                value = settings.axis[idx].limit_pos;
+            break;
 #if ENABLE_BACKLASH_COMPENSATION
             case Setting_AxisBacklash:
                 value = settings.axis[idx].backlash;

--- a/settings.h
+++ b/settings.h
@@ -515,9 +515,9 @@ typedef enum {
     Setting_AxisMicroSteps       = Setting_AxisSettingsBase + 5 * AXIS_SETTINGS_INCREMENT,
     Setting_AxisBacklash         = Setting_AxisSettingsBase + 6 * AXIS_SETTINGS_INCREMENT,
     Setting_AxisAutoSquareOffset = Setting_AxisSettingsBase + 7 * AXIS_SETTINGS_INCREMENT,
-    Setting_AxisHomingFeedRate   = Setting_AxisSettingsBase + 8 * AXIS_SETTINGS_INCREMENT,
-    Setting_AxisHomingSeekRate   = Setting_AxisSettingsBase + 9 * AXIS_SETTINGS_INCREMENT,
-
+   // Setting_AxisHomingFeedRate   = Setting_AxisSettingsBase + 8 * AXIS_SETTINGS_INCREMENT,
+   // Setting_AxisHomingSeekRate   = Setting_AxisSettingsBase + 9 * AXIS_SETTINGS_INCREMENT,
+    Setting_AxisLimitPos         = Setting_AxisSettingsBase + 8 * AXIS_SETTINGS_INCREMENT,
     // Calculated base values for driver/plugin stepper settings
     Setting_AxisExtended0        = Setting_AxisSettingsBase2,
     Setting_AxisExtended1        = Setting_AxisSettingsBase2 + AXIS_SETTINGS_INCREMENT,
@@ -716,6 +716,7 @@ typedef struct {
     float acceleration;
     float max_travel;
     float dual_axis_offset;
+    float limit_pos;
 #if ENABLE_BACKLASH_COMPENSATION
     float backlash;
 #endif

--- a/stepper2.c
+++ b/stepper2.c
@@ -151,6 +151,7 @@ static const char *st2_set_axis_setting_unit (setting_id_t setting_id, uint_fast
             break;
 
         case Setting_AxisMaxTravel:
+        case Setting_AxisLimitPos:
         case Setting_AxisBacklash:
             unit = "--";
             break;
@@ -192,6 +193,7 @@ static const char *st2_setting_get_description (setting_id_t id)
             break;
 
         case Setting_AxisBacklash:
+        case Setting_AxisLimitPos:
         case Setting_AxisMaxTravel:
             if(bit_istrue(spindle_motors, bit(axis_idx)))
                 descr = "This setting is ignored for stepper spindles.";


### PR DESCRIPTION
I have a suggestion for homing.
The negative home positions are not common for non-professional machines and are therefore rather confusing.
My machine, for example, has the Y motors and the limit switches on the 
Max Position.Setting the origin to 0 is therefore not applicable.
When reversing the homing direction I have the negative positions.
I therefore added a “Limit Pos” setting for the axes.
I can now define the position of the limit switches for each axis. This means it doesn't matter where the limit switches are mounted and I always have a defined position.
These changes may not be fully developed but will work.
Please excuse my English, I come from German-speaking countries.
I hope the pull request is correct. I very rarely work with git