### PR TITLE
Core changes to support the FlexGPIO I2C expander as used on FlexiHAL 2350

### DIFF
--- a/expanders_init.h
+++ b/expanders_init.h
@@ -56,7 +56,7 @@ extern void pca9654e_init(void);
 // Third party I2C expander plugins goes after this line
 
 #if FLEXGPIO_ENABLE
-extern void flexgpio_io_init (void);
+extern void flexgpio_init (void);
 #endif
 
 #endif // I2C expanders
@@ -118,6 +118,6 @@ static inline void io_expanders_init (void)
 #endif
 
 #if FLEXGPIO_ENABLE
-    flexgpio_io_init ();
+    flexgpio_init ();
 #endif
 }

--- a/expanders_init.h
+++ b/expanders_init.h
@@ -31,7 +31,7 @@ extern void board_ports_init (void); // default is a weak function
 
 // I2C expanders
 
-#if PCA9654E_ENABLE || MCP3221_ENABLE || MCP4725_ENABLE
+#if PCA9654E_ENABLE || MCP3221_ENABLE || MCP4725_ENABLE || FLEXGPIO_ENABLE
 
 #if defined(I2C_ENABLE) && !I2C_ENABLE
 #undef I2C_ENABLE
@@ -54,6 +54,10 @@ extern void pca9654e_init(void);
 #endif
 
 // Third party I2C expander plugins goes after this line
+
+#if FLEXGPIO_ENABLE
+extern void flexgpio_io_init (void);
+#endif
 
 #endif // I2C expanders
 
@@ -111,5 +115,9 @@ static inline void io_expanders_init (void)
 
 #if PICOHAL_IO_ENABLE
     picohal_io_init();
+#endif
+
+#if FLEXGPIO_ENABLE
+    flexgpio_io_init ();
 #endif
 }

--- a/pin_bits_masks.h
+++ b/pin_bits_masks.h
@@ -440,6 +440,24 @@ static aux_ctrl_out_t aux_ctrl_out[] = {
 #if defined(Z_ENABLE_PIN) && Z_ENABLE_PORT == EXPANDER_PORT
     { .function = Output_StepperEnableZ, .aux_port = 0xFF, .pin = Z_ENABLE_PIN,   .port = (void *)Z_ENABLE_PORT },
 #endif
+#if defined(Z_ENABLE_PIN) && A_ENABLE_PORT == EXPANDER_PORT
+    { .function = Output_StepperEnableA, .aux_port = 0xFF, .pin = A_ENABLE_PIN,   .port = (void *)A_ENABLE_PORT },
+#endif
+#if defined(B_ENABLE_PIN) && B_ENABLE_PORT == EXPANDER_PORT
+    { .function = Output_StepperEnableB, .aux_port = 0xFF, .pin = B_ENABLE_PIN,   .port = (void *)B_ENABLE_PORT },
+#endif
+#if defined(C_ENABLE_PIN) && C_ENABLE_PORT == EXPANDER_PORT
+    { .function = Output_StepperEnableC, .aux_port = 0xFF, .pin = C_ENABLE_PIN,   .port = (void *)C_ENABLE_PORT },
+#endif
+#if defined(X2_ENABLE_PIN) && X2_ENABLE_PORT == EXPANDER_PORT
+    { .function = Output_StepperEnableX2, .aux_port = 0xFF, .pin = X2_ENABLE_PIN,   .port = (void *)X2_ENABLE_PORT },
+#endif
+#if defined(Y2_ENABLE_PIN) && Y2_ENABLE_PORT == EXPANDER_PORT
+    { .function = Output_StepperEnableY2, .aux_port = 0xFF, .pin = Y2_ENABLE_PIN,   .port = (void *)Y2_ENABLE_PORT },
+#endif
+#if defined(Z2_ENABLE_PIN) && Z2_ENABLE_PORT == EXPANDER_PORT
+    { .function = Output_StepperEnableZ2, .aux_port = 0xFF, .pin = Z2_ENABLE_PIN,   .port = (void *)Z2_ENABLE_PORT },
+#endif
 #endif
 #if AUX_CONTROLS & AUX_CONTROL_SPINDLE
 #ifdef SPINDLE_ENABLE_PIN


### PR DESCRIPTION
Added functions for using the FlexGPIO I2C expander.  Hopefully this is a reasonable implementation with the new API.

Plugin repo is here:
https://github.com/Expatria-Technologies/plugin_FlexGPIO

Actual expander code repo is here:
https://github.com/Expatria-Technologies/FlexGPIO

Board schematics (repo and readme are WIP):
[FLEXI_HAL_PRO_Schematic_A3_FULL_PLACE.PDF](https://github.com/user-attachments/files/20497367/FLEXI_HAL_PRO_Schematic_A3_FULL_PLACE.PDF)
https://github.com/Expatria-Technologies/FlexiHAL_2350