### PR TITLE
Fix feed override bypass when programmed rate exceeds rapid rate

### DIFF
--- a/planner.c
+++ b/planner.c
@@ -313,6 +313,8 @@ float plan_compute_profile_nominal_speed (plan_block_t *block)
     if(block->condition.rapid_motion)
         nominal_speed *= (0.01f * (float)sys.override.rapid_rate);
     else {
+		if(nominal_speed > block->rapid_rate)
+            nominal_speed = block->rapid_rate;
         if(!block->condition.no_feed_override)
             nominal_speed *= (0.01f * (float)sys.override.feed_rate);
         if(nominal_speed > block->rapid_rate)


### PR DESCRIPTION
Added a check to ensure nominal_speed does not exceed rapid_rate before applying feed override. prevent feed_rate settings from not working when programmed_rate exceeds rapid_rate.