### PR TITLE
Add realtime report of distance-to-go 

### DIFF
--- a/config.h
+++ b/config.h
@@ -617,11 +617,21 @@ in the real time report.
 #define DEFAULT_REPORT_LINE_NUMBERS On // Default on. Set to \ref Off or 0 to disable.
 #endif
 
+/*! \def DEFAULT_REPORT_DISTANCE_TO_GO
+\brief
+If set to \ref Off or 0 the `|DTG:` distance-to-go element is not included
+in the real time report.
+\internal Bit 3 in settings.status_report.
+*/
+#if !defined DEFAULT_REPORT_DISTANCE_TO_GO || defined __DOXYGEN__
+#define DEFAULT_REPORT_DISTANCE_TO_GO On // Default on. Set to \ref Off or 0 to disable.
+#endif
+
 /*! \def DEFAULT_REPORT_CURRENT_FEED_SPEED
 \brief
 If set to \ref Off or 0 the `|FS:` current feed & speed element is not included
 in the real time report.
-\internal Bit 3 in settings.status_report.
+\internal Bit 4 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_CURRENT_FEED_SPEED || defined __DOXYGEN__
 #define DEFAULT_REPORT_CURRENT_FEED_SPEED On // Default on. Set to \ref Off or 0 to disable.
@@ -631,7 +641,7 @@ in the real time report.
 \brief
 If set to \ref Off or 0 the `|Pn:` input pins state element is not included
 in the real time report.
-\internal Bit 4 in settings.status_report.
+\internal Bit 5 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_PIN_STATE || defined __DOXYGEN__
 #define DEFAULT_REPORT_PIN_STATE On // Default on. Set to \ref Off or 0 to disable.
@@ -641,7 +651,7 @@ in the real time report.
 \brief
 If set to \ref Off or 0 the `|WCO:` work coordinate offset element is not included
 in the real time report.
-\internal Bit 5 in settings.status_report.
+\internal Bit 6 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_WORK_COORD_OFFSET || defined __DOXYGEN__
 #define DEFAULT_REPORT_WORK_COORD_OFFSET On // Default on. Set to \ref Off or 0 to disable.
@@ -651,7 +661,7 @@ in the real time report.
 \brief
 If set to \ref Off or 0 the `|Pn:` input pins state element is not included
 in the real time report.
-\internal Bit 6 in settings.status_report.
+\internal Bit 7 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_OVERRIDES || defined __DOXYGEN__
 #define DEFAULT_REPORT_OVERRIDES On // Default on. Set to \ref Off or 0 to disable.
@@ -662,7 +672,7 @@ in the real time report.
 Upon a successful probe cycle, this option provides immediately feedback of the probe coordinates
 through an automatically generated message. If disabled, users can still access the last probe
 coordinates through grblHAL `$#` print parameters command.
-\internal Bit 7 in settings.status_report.
+\internal Bit 8 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_PROBE_COORDINATES || defined __DOXYGEN__
 #define DEFAULT_REPORT_PROBE_COORDINATES On // Default on. Set to \ref Off or 0 to disable.
@@ -676,7 +686,7 @@ can be several motions behind. This option forces the planner buffer to empty, s
 motion whenever there is a command that alters the work coordinate offsets `G10,G43.1,G92,G54-59.3`.
 This is the simplest way to ensure `WPos:` is always correct. Fortunately, it's exceedingly rare
 that any of these commands are used need continuous motions through them.
-\internal Bit 8 in settings.status_report.
+\internal Bit 9 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_SYNC_ON_WCO_CHANGE || defined __DOXYGEN__
 #define DEFAULT_REPORT_SYNC_ON_WCO_CHANGE On //!< ok
@@ -687,7 +697,7 @@ that any of these commands are used need continuous motions through them.
 When enabled adds automatic report of the parser state following a status report request
 if the state was changed since the last report. The output is the same as provided by
 the `$G` command.
-\internal Bit 9 in settings.status_report.
+\internal Bit 10 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_PARSER_STATE || defined __DOXYGEN__
 #define DEFAULT_REPORT_PARSER_STATE Off // Default off. Set to \ref On or 1 to enable.
@@ -701,7 +711,7 @@ normally no way to determine the cause of the alarm. Enabling this setting adds 
 code (see \ref alarm_code_t) as a substate, separated by a colon, to the _Alarm_ state in
 the real time report.
 <br>__NOTE:__ Enabling this option may break senders.
-\internal Bit 10 in settings.status_report.
+\internal Bit 11 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_ALARM_SUBSTATE || defined __DOXYGEN__
 #define DEFAULT_REPORT_ALARM_SUBSTATE Off // Default off. Set to \ref On or 1 to enable.
@@ -714,7 +724,7 @@ The following codes are defined:
 + `1` - a feed hold is pending, waiting for spindle synchronized motion to complete.
 + `2` - the motion is a probe.
 <br>__NOTE:__ Enabling this option may break senders.
-\internal Bit 11 in settings.status_report.
+\internal Bit 12 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_RUN_SUBSTATE || defined __DOXYGEN__
 #define DEFAULT_REPORT_RUN_SUBSTATE Off // Default off. Set to \ref On or 1 to enable.
@@ -724,7 +734,7 @@ The following codes are defined:
 \brief
 Enabling this setting enables status reporting while homing.
 <br>__NOTE:__ Enabling this option may break senders.
-\internal Bit 12 in settings.status_report.
+\internal Bit 13 in settings.status_report.
 */
 #if !defined DEFAULT_REPORT_WHEN_HOMING || defined __DOXYGEN__
 #define DEFAULT_REPORT_WHEN_HOMING Off // Default off. Set to \ref On or 1 to enable.

--- a/planner.c
+++ b/planner.c
@@ -417,6 +417,7 @@ bool plan_buffer_line (float *target, plan_line_data_t *pl_data)
     block->offset_id = pl_data->offset_id;
     block->output_commands = pl_data->output_commands;
     block->message = pl_data->message;
+    memcpy(block->target_mm, target, sizeof(float) * N_AXIS);
 
     // Copy position data based on type of motion being planned.
     memcpy(position_steps, block->condition.system_motion ? sys.position : pl.position, sizeof(position_steps));

--- a/planner.h
+++ b/planner.h
@@ -82,6 +82,7 @@ typedef struct plan_block {
     gc_override_flags_t overrides;  // Block bitfield variable for overrides
     planner_cond_t condition;       // Block bitfield variable defining block run conditions. Copied from pl_line_data.
     int32_t line_number;            // Block line number for real-time reporting. Copied from pl_line_data.
+    float target_mm[N_AXIS];        // Block target end location in mm for real-time reporting of distance to go.
 
     // Fields used by the motion planner to manage acceleration. Some of these values may be updated
     // by the stepper module during execution of special motion cases for replanning purposes.

--- a/report.c
+++ b/report.c
@@ -1254,18 +1254,20 @@ void report_realtime_status (stream_write_ptr stream_write)
             stream_write(appendbuf(2, "|Ln:", uitoa((uint32_t)cur_block->line_number)));
     }
 
-    // Report distance remaining as difference between target (end of block) and current position
-    plan_block_t *cur_block = plan_get_current_block();
-    if (cur_block != NULL) {
-        system_convert_array_steps_to_mpos(dist_remaining, sys.position);
+    if(settings.status_report.distance_to_go) {
+        // Report distance-to-go in current block (i.e., difference between target / end-of-block) and current position)
+        plan_block_t *cur_block = plan_get_current_block();
+        if (cur_block != NULL) {
+            system_convert_array_steps_to_mpos(dist_remaining, sys.position);
 
-        for(idx = 0; idx < N_AXIS; idx++) {
-            dist_remaining[idx] = cur_block->target_mm[idx] - dist_remaining[idx];
+            for(idx = 0; idx < N_AXIS; idx++) {
+                dist_remaining[idx] = cur_block->target_mm[idx] - dist_remaining[idx];
+            }
+
+            hal.stream.write_all("|DTG:");
+            hal.stream.write_all(get_axis_values(dist_remaining));
         }
-        // Report distance to go
-        hal.stream.write_all("|DToGo:");
-        hal.stream.write_all(get_axis_values(dist_remaining));
-    }
+    }   
 
     spindle_ptrs_t *spindle_0;
     spindle_state_t spindle_0_state;

--- a/settings.c
+++ b/settings.c
@@ -152,6 +152,7 @@ PROGMEM const settings_t defaults = {
     .status_report.machine_position = DEFAULT_REPORT_MACHINE_POSITION,
     .status_report.buffer_state = DEFAULT_REPORT_BUFFER_STATE,
     .status_report.line_numbers = DEFAULT_REPORT_LINE_NUMBERS,
+    .status_report.distance_to_go = DEFAULT_REPORT_DISTANCE_TO_GO,
     .status_report.feed_speed = DEFAULT_REPORT_CURRENT_FEED_SPEED,
     .status_report.pin_state = DEFAULT_REPORT_PIN_STATE,
     .status_report.work_coord_offset = DEFAULT_REPORT_WORK_COORD_OFFSET,
@@ -2014,7 +2015,7 @@ PROGMEM static const setting_detail_t setting_detail[] = {
      { Setting_GangedDirInvertMask, Group_Stepper, "Ganged axes direction invert", NULL, Format_Bitfield, ganged_axes, NULL, NULL, Setting_IsExtendedFn, set_ganged_dir_invert, get_int, is_setting_available },
      { Setting_SpindlePWMOptions, Group_Spindle, "PWM spindle options", NULL, Format_XBitfield, "Enable,RPM controls spindle enable signal,Disable laser mode capability", NULL, NULL, Setting_IsExtendedFn, set_pwm_options, get_int, is_setting_available },
 #if COMPATIBILITY_LEVEL <= 1
-     { Setting_StatusReportMask, Group_General, "Status report options", NULL, Format_Bitfield, "Position in machine coordinate,Buffer state,Line numbers,Feed & speed,Pin state,Work coordinate offset,Overrides,Probe coordinates,Buffer sync on WCO change,Parser state,Alarm substatus,Run substatus,Enable when homing", NULL, NULL, Setting_IsExtendedFn, set_report_mask, get_int, NULL },
+     { Setting_StatusReportMask, Group_General, "Status report options", NULL, Format_Bitfield, "Position in machine coordinate,Buffer state,Line numbers,Distance-to-go,Feed & speed,Pin state,Work coordinate offset,Overrides,Probe coordinates,Buffer sync on WCO change,Parser state,Alarm substatus,Run substatus,Enable when homing", NULL, NULL, Setting_IsExtendedFn, set_report_mask, get_int, NULL },
 #else
      { Setting_StatusReportMask, Group_General, "Status report options", NULL, Format_Bitfield, "Position in machine coordinate,Buffer state", NULL, NULL, Setting_IsLegacyFn, set_report_mask, get_int, NULL },
 #endif

--- a/settings.h
+++ b/settings.h
@@ -631,6 +631,7 @@ typedef union {
         uint16_t machine_position   :1,
                  buffer_state       :1,
                  line_numbers       :1,
+                 distance_to_go     :1,
                  feed_speed         :1,
                  pin_state          :1,
                  work_coord_offset  :1,
@@ -641,7 +642,7 @@ typedef union {
                  alarm_substate     :1,
                  run_substate       :1,
                  when_homing        :1,
-                 unassigned         :3;
+                 unassigned         :2;
     };
 } reportmask_t;
 


### PR DESCRIPTION
I found myself missing a feature from industrial controls (e.g., FANUC) which show the remaining distance in the current travel move (i.e., currently executing block) as a distance-to-go readout. This PR adds support for computing this distance in the planner and a setting for adding it to the realtime report between the buffer and line numbers.

If you are open to it, I would also like to explore options for displaying these values in iosender, but that is likely a subject for a separate PR.