### PR TITLE
Added Sienci ATC plugin init and m-code reservation

### DIFF
--- a/gcode.h
+++ b/gcode.h
@@ -62,7 +62,7 @@ typedef enum {
     NonModal_ClearCoordinateOffset = 112,   //!< 112 - G92.2
  #if ENABLE_ACCELERATION_PROFILES
     NonModal_RestoreCoordinateOffset = 122, //!< 122 - G92.3
-    NonModal_SetAccelerationProfile = 187   //!< 187 - G187 
+    NonModal_SetAccelerationProfile = 187   //!< 187 - G187
  #else
     NonModal_RestoreCoordinateOffset = 122 //!< 122 - G92.3
  #endif
@@ -277,6 +277,7 @@ typedef enum {
     Trinamic_HybridThreshold = 913,     //!< 913 - M913, Marlin format
     Trinamic_HomingSensitivity = 914,   //!< 914 - M914, Marlin format
     Trinamic_ChopperTiming = 919,       //!< 919 - M919, Marlin format
+    Sienci_Atci_Enable = 960,           //!< 960 - M960
     Spindle_Select = UserMCode_Generic4 //!< Value to be assigned later!
 } user_mcode_t;
 

--- a/plugins_init.h
+++ b/plugins_init.h
@@ -238,6 +238,12 @@
     event_out_init();
 #endif
 
+#if ATCI_ENABLE
+  extern void atci_init(void);
+  atci_init();
+#endif
+
+
 // End third party plugin definitions.
 
 #if ODOMETER_ENABLE


### PR DESCRIPTION
Good morning! 

PR to support the Sienci ATC plugin: https://github.com/Sienci-Labs/sienci-atci-plugin

I've added the CMakeLists.txt to plugin as well 

In this PR I've added the Init and (hopefully correctly) the M-Code reservation. 
I have not updated the GRBL_BUILD as its still the same date as your last commit at the time of the PR

