### PR TITLE
Fix -Werror=calloc-transposed-args with gcc 14.

### DIFF
--- a/fs_device.c
+++ b/fs_device.c
@@ -43,7 +43,7 @@ bool device_fs_add_stream (io_stream_properties_t *stream)
     if(!stream->flags.claimable || !stream->flags.modbus_ready)
         return false;
 
-    fs_device_t *add = calloc(sizeof(fs_device_t), 1);
+    fs_device_t *add = calloc(1, sizeof(fs_device_t));
     if(add) {
 
         switch(stream->type) {
@@ -119,7 +119,7 @@ static vfs_file_t *fs_open (const char *filename, const char *mode)
 
         device->io_stream.state.passthru = On; // flag open
 
-        if((file = calloc(sizeof(vfs_file_t) + sizeof(io_stream_t *), 1))) {
+        if((file = calloc(1, sizeof(vfs_file_t) + sizeof(io_stream_t *)))) {
             io_stream = &device->io_stream;
 #ifdef __GNUC__
 #pragma GCC diagnostic push

--- a/gcode.c
+++ b/gcode.c
@@ -663,7 +663,7 @@ FLASHMEM static status_code_t macro_add (macro_id_t id, vfs_file_t *file)
 {
     m98_macro_t *sub = macro_find(id);
 
-    if(sub == NULL && (sub = calloc(sizeof(m98_macro_t), 1))) {
+    if(sub == NULL && (sub = calloc(1, sizeof(m98_macro_t)))) {
         sub->id = id;
         sub->file = file;
         if(m98_macros) {

--- a/ioports.c
+++ b/ioports.c
@@ -827,7 +827,7 @@ FLASHMEM static io_ports_list_t *insert_ports (void)
 {
     io_ports_list_t *io_ports;
 
-    if((io_ports = calloc(sizeof(io_ports_list_t), 1))) {
+    if((io_ports = calloc(1, sizeof(io_ports_list_t)))) {
 
         if(ports == NULL)
             ports = io_ports;

--- a/stepper2.c
+++ b/stepper2.c
@@ -258,7 +258,7 @@ st2_motor_t *st2_motor_init (uint_fast8_t axis_idx, bool is_spindle)
 {
     st2_motor_t *motor = NULL, *new = motors;
 
-    if(hal.stepper.output_step && (motor = calloc(sizeof(st2_motor_t), 1))) {
+    if(hal.stepper.output_step && (motor = calloc(1, sizeof(st2_motor_t)))) {
 
         if(hal.timer.claim && (motor->step_inject_timer = hal.timer.claim((timer_cap_t){ .periodic = Off }, 1000))) {
             timer_cfg_t step_inject_cfg = {

--- a/stream_json.c
+++ b/stream_json.c
@@ -36,7 +36,7 @@ json_out_t *json_start (vfs_file_t *file, uint32_t max_levels)
 {
     json_out_t *handle = NULL;
 
-    if(file && (handle = calloc(sizeof(json_out_t) + sizeof(uint32_t) * max_levels, 1))) {
+    if(file && (handle = calloc(1, sizeof(json_out_t) + sizeof(uint32_t) * max_levels))) {
         handle->file = file;
         handle->max_level = max_levels;
         vfs_write("{", 1, 1, handle->file);

--- a/vfs.c
+++ b/vfs.c
@@ -108,7 +108,7 @@ static vfs_dir_t *fs_opendir (const char *path)
     static vfs_dir_t *dir = NULL;
 
     if(dir == NULL)
-        dir = calloc(sizeof(vfs_dir_t) + 3, 1);
+        dir = calloc(1, sizeof(vfs_dir_t) + 3);
 
     if(dir) {
         vfs_mount_t **mount = (vfs_mount_t **)&dir->handle;
@@ -587,7 +587,7 @@ bool vfs_mount (const char *path, const vfs_t *fs, vfs_st_mode_t mode)
     if(!strcmp(path, "/")) {
         root.vfs = fs;
         root.mode = mode;
-    } else if((mount = (vfs_mount_t *)calloc(sizeof(vfs_mount_t), 1))) {
+    } else if((mount = (vfs_mount_t *)calloc(1, sizeof(vfs_mount_t)))) {
 
         struct tm tm;
 


### PR DESCRIPTION
gcc 14 introduces calloc-transposed-args, which checks that calls to calloc() conform to the "num, size" order of arguments.

Most of the calls in grblHAL are correct, but a few were not.