### PR TITLE
Fix include guard mismatch.

### DIFF
--- a/strutils.h
+++ b/strutils.h
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef __STRUTILS_H__
-#define __STRUTILS_H___
+#define __STRUTILS_H__
 
 #include <stdint.h>
 #include <time.h>


### PR DESCRIPTION
Found by gcc14:
`strutils.h:34: error: header guard '__STRUTILS_H__' followed by '#define' of a different macro [-Werror=header-guard]`