### PR TITLE
Add code guards to prevent hard crash on $REBOOT for unsupported drivers

### DIFF
--- a/system.c
+++ b/system.c
@@ -787,12 +787,14 @@ FLASHMEM static status_code_t rtc_action (sys_state_t state, char *args)
 
 FLASHMEM static status_code_t reboot_system (sys_state_t state, char *args)
 {
-    report_message("Rebooting controller, communication may be lost", Message_Warning);
-    hal.delay_ms(100, NULL);
+    if (hal.reboot) {
+        report_message("Rebooting controller, communication may be lost", Message_Warning);
+        hal.delay_ms(100, NULL);
 
-    hal.reboot();
+        hal.reboot();
+    }
     
-    return Status_OK;
+    return hal.reboot ? Status_OK : Status_InvalidStatement;
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
While testing support for `$REBOOT` command on RP2040 driver, I realized that it would currently hard fault rather than reject the invalid command. This PR should hopefully add the necessary code guards to prevent that behaviour. Tested only with RP2040.