### PR TITLE
Add [BUILD:...] line to $I from optional build_stamp.h

### DIFF
--- a/report.c
+++ b/report.c
@@ -1107,6 +1107,19 @@ FLASHMEM void report_build_info (char *line, bool extended)
             hal.stream.write("]" ASCII_EOL);
         }
 
+        // Compile-time stamp for confirming the running .hex matches a
+        // specific local build, rather than relying on GRBL_BUILD (a
+        // hand-edited literal in grbl.h that doesn't track local rebuilds).
+        // Opt-in: a driver that provides a build_stamp.h with a
+        // BUILD_TIMESTAMP string macro gets the [BUILD:...] line; drivers
+        // that don't provide the header are unaffected.
+#if defined(__has_include)
+  #if __has_include("build_stamp.h")
+        #include "build_stamp.h"
+        hal.stream.write("[BUILD:" BUILD_TIMESTAMP "]" ASCII_EOL);
+  #endif
+#endif
+
         if(hal.driver_options) {
             hal.stream.write("[DRIVER OPTIONS:");
             hal.stream.write(hal.driver_options);


### PR DESCRIPTION
## Summary (opened as draft for discussion)

`GRBL_BUILD` in `grbl.h` is a hand-edited integer literal that only changes when an upstream release is tagged. Operators rebuilding firmware locally have no way to confirm via `$I` that the running `.hex` matches the one they just produced.

This PR adds a `[BUILD:<date> <time>]` line to `$I` reporting, guarded by `__has_include("build_stamp.h")`. Drivers that ship a `build_stamp.h` defining `BUILD_TIMESTAMP` get the line; drivers that don't are completely unaffected — no behavior change without an explicit opt-in.

## Why draft

Marked as draft because the build-stamping mechanism is a design choice that should probably get Terje's blessing first. Happy to drop this, change the include name, change the line name (e.g. `[VER:...]` vs `[BUILD:...]`), or use a different conditional if there's a preferred convention.

## Driver-side plumbing (intentionally not in this PR)

The matching driver-side bit is a small pre-build script that regenerates `build_stamp.h` on every compile. That lives in each driver, not core — keeps this PR to a single-line conditional in `report.c`.

## Test plan

- [x] With `build_stamp.h` present defining `BUILD_TIMESTAMP "2026-06-15 22:14:32"`: `$I` shows `[BUILD:2026-06-15 22:14:32]`.
- [x] With `build_stamp.h` absent: `$I` unchanged.
