### PR TITLE
Fix copy-paste bug for Setting_LimitPinsInvertMask ($5)

### DIFF
--- a/settings.c
+++ b/settings.c
@@ -608,9 +608,9 @@ FLASHMEM static status_code_t set_axis_mask (setting_id_t id, uint_fast16_t valu
 
         case Setting_LimitPinsInvertMask:
 #if COMPATIBILITY_LEVEL > 1
-    		settings.steppers.enable_invert.mask = value ? 0 : AXES_BITMASK;
+            settings.limits.invert.mask = value ? (~DEFAULT_LIMIT_SIGNALS_INVERT_MASK & AXES_BITMASK) : DEFAULT_LIMIT_SIGNALS_INVERT_MASK;
 #else
-    		settings.steppers.enable_invert.mask = value;
+            settings.limits.invert.mask = value;
 #endif
             break;
 
@@ -687,9 +687,9 @@ FLASHMEM static uint32_t get_axis_mask (setting_id_t id, uint_fast16_t int_value
 
         case Setting_LimitPinsInvertMask:
 #if COMPATIBILITY_LEVEL > 1
-            value = settings.steppers.enable_invert.mask == DEFAULT_LIMIT_SIGNALS_INVERT_MASK ? 0 : 1;
+            value = settings.limits.invert.mask == DEFAULT_LIMIT_SIGNALS_INVERT_MASK ? 0 : 1;
 #else
-            value = settings.steppers.enable_invert.mask;
+            value = settings.limits.invert.mask;
 #endif
             break;
 


### PR DESCRIPTION
This PR fixes a copy-paste bug in `grbl/settings.c` that prevents the Limit Pins Invert Mask setting (`$5`) from working correctly.

### Issue
In both `set_axis_mask` and `get_axis_mask` functions under the `Setting_LimitPinsInvertMask` case, the code incorrectly accesses `settings.steppers.enable_invert.mask` instead of `settings.limits.invert.mask`. 

Because of this:
1. Attempting to change setting `$5` (e.g. via iOSender or console) ends up modifying the stepper enable pin inversion instead of the limit pin inversion.
2. The limit switches cannot be inverted at run-time, leading to switches incorrectly reporting active states.

### Solution
Replaced `settings.steppers.enable_invert.mask` with `settings.limits.invert.mask` in both `set_axis_mask` and `get_axis_mask` for the `Setting_LimitPinsInvertMask` case.
