### PR TITLE
fix: use labs() instead of abs() for int32_t delta in auto-squaring check

### DIFF
--- a/machine_limits.c
+++ b/machine_limits.c
@@ -429,7 +429,7 @@ FLASHMEM static bool homing_cycle (axes_signals_t cycle, axes_signals_t auto_squ
 
                 sys.homing_axis_lock.mask = axislock.mask;
 
-                if(autosquare_check && abs(initial_trigger_position - sys.position[dual_motor_axis]) > autosquare_fail_distance) {
+                if(autosquare_check && labs(initial_trigger_position - sys.position[dual_motor_axis]) > autosquare_fail_distance) {
                     system_set_exec_alarm(Alarm_HomingFailAutoSquaringApproach);
                     mc_reset();
                     protocol_execute_realtime();


### PR DESCRIPTION
abs() is declared as int abs(int). int isn't guaranteed to be 32 bits, only at least 16. On a target where int is narrower than 32 bits, a 32-bit value passed to abs() gets truncated before the absolute value is computed.

initial_trigger_position and sys.position[] are both int32_t here. labs() takes a long, and long is guaranteed at least 32 bits, so it's wide enough to hold the 32-bit value without truncation, unlike abs().

This matches the existing pattern at planner.c:445, where labs(delta_steps) is applied to delta_steps = target_steps[idx] - position_steps[idx], an int32_t step-count difference of the same shape as this fix.