### PR TITLE
G53 moves incorrectly apply the active WCS rotation/offset (when ROTATION_ENABLE=1)

### DIFF
--- a/gcode.c
+++ b/gcode.c
@@ -3053,7 +3053,12 @@ status_code_t gc_execute_block (char *block)
 #ifdef ROTATION_ENABLE
                 axes_signals_t r_axes, r_around;
                 uint_fast8_t idx_0, idx_1;
-                if(!gc_parser_flags.jog_motion && (r_axes.mask = (gc_block.modal.g5x_offset.data.rotation == 0.0f ? 0 : (axis_words.mask & (r_around.mask = rotate_axes[gc_block.modal.plane_select].mask))))) {
+                r_axes.mask = 0;   // keep defined when the transform is bypassed (jog / G53)
+                // G53 (absolute machine override) must ignore the active WCS entirely - rotation AND offset. Without
+                // the AbsoluteOverride guard this block adds the g5x offset to the plane axes, so e.g. "G53 G0 X0 Y0"
+                // goes to the work origin instead of machine 0,0 (and false soft-limits when that lands out of travel).
+                // A near-zero garbage rotation (stale NVS after enabling ROTATION_ENABLE) is enough to arm it.
+                if(!gc_parser_flags.jog_motion && gc_block.non_modal_command != NonModal_AbsoluteOverride && (r_axes.mask = (gc_block.modal.g5x_offset.data.rotation == 0.0f ? 0 : (axis_words.mask & (r_around.mask = rotate_axes[gc_block.modal.plane_select].mask))))) {
 
                     if(r_axes.mask != r_around.mask) {
                         point_3d_t pos;


### PR DESCRIPTION
**Scope:** Only affects builds compiled with `ROTATION_ENABLE` — the offending code is inside `#ifdef ROTATION_ENABLE`. Default builds are unaffected; `G53` is handled correctly there.

With `ROTATION_ENABLE` and a non-zero coordinate-system rotation active, **`G53` (non-modal absolute machine override) moves are transformed by the active WCS's rotation and offset.** Per RS274/NGC a `G53` target is in the machine coordinate system and must ignore all offsets (WCS, G92, tool-length) and rotation. Instead the move is sent to the (rotated) work origin, and — with soft limits on — false-triggers `Alarm:2` when that lands outside the machine envelope.

**Root cause** — `gc_execute_block` (`gcode.c`): the rotation-transform block is entered for any axis-word motion **without excluding `NonModal_AbsoluteOverride`**. It adds the g5x offset to the plane axes and rotates. The target loop just below *does* exclude `G53` from the offset (`else if(gc_block.non_modal_command != NonModal_AbsoluteOverride)`) — the rotation block above it does not, so `G53` picks up the offset via the rotation path.

**Reproduce** (ROTATION_ENABLE build, homed, `$20=1`):

```
G10 L2 P1 X100 Y-100 Z0 R5   ; G54: origin at machine (100,-100), 5 deg rotation
G54
G53 G0 X0 Y0                 ; expect machine 0,0
```

The machine drives toward the rotated work origin instead of machine (0,0) — the DRO confirms the wrong position even without soft limits; with `$20=1` it raises `Alarm:2` when the target exits travel.

**Fix** (this PR) — exclude `G53` from the transform: guard the rotation block with `gc_block.non_modal_command != NonModal_AbsoluteOverride`, and initialise `r_axes.mask = 0` so it stays defined when the block is bypassed.
