### PR TITLE
Fix feedrate calculation for rotary axes moves in G20 (imperial units)

### DIFF
--- a/planner.c
+++ b/planner.c
@@ -497,24 +497,31 @@ bool plan_buffer_line (float *target, plan_line_data_t *pl_data)
 
     if(!block->condition.inverse_time &&
         !block->condition.rapid_motion &&
-         (motion.mask & settings.steppers.is_rotary.mask) &&
-          (motion.mask & ~settings.steppers.is_rotary.mask)) {
+        (motion.mask & settings.steppers.is_rotary.mask)){
+            
+        if(motion.mask & ~settings.steppers.is_rotary.mask) {
 
-        float linear_magnitude = 0.0f;
+            float linear_magnitude = 0.0f;
 
-        idx = 0;
-        motion.mask &= ~settings.steppers.is_rotary.mask;
+            idx = 0;
+            motion.mask &= ~settings.steppers.is_rotary.mask;
 
-        while(motion.mask) {
-            if(motion.mask & 0x01)
-                linear_magnitude += unit_vec[idx] * unit_vec[idx];
-            motion.mask >>= 1;
-            idx++;
+            while(motion.mask) {
+                if(motion.mask & 0x01)
+                    linear_magnitude += unit_vec[idx] * unit_vec[idx];
+                motion.mask >>= 1;
+                idx++;
+            }
+
+            pl_data->feed_rate = 1.0f / (sqrtf(linear_magnitude) / pl_data->feed_rate);
+
+            block->condition.inverse_time = On;
+
+        } else {
+            // Reverse in/min to mm/min conversion for rotary axes
+            if(gc_state.modal.units_imperial)
+                pl_data->feed_rate /= 25.4f;
         }
-
-        pl_data->feed_rate = 1.0f / (sqrtf(linear_magnitude) / pl_data->feed_rate);
-
-        block->condition.inverse_time = On;
     }
 
 #endif


### PR DESCRIPTION
It seems that the feed-rate used for movements involving only rotary axes is still scaled by a factor of 25.4 when imperial unit modal state (G20) is active.

The proposed correction here is only applied within the `ROTARY_FIX` code guard, but could make sense to apply in general. Also, since the change is applied at the planner level, the *corrected* feed-rate is not displayed in the parser state of ioSender, but I could not think of a way to do so which would not create potential issues for subsequent moves that did not provide a new F-code.