### PR TITLE
Re-enable both motors after auto squaring offset pull-off

### DIFF
--- a/machine_limits.c
+++ b/machine_limits.c
@@ -525,6 +525,7 @@ FLASHMEM static bool homing_cycle (axes_signals_t cycle, axes_signals_t auto_squ
 #endif
         if(!limits_pull_off(auto_square, &distance, 1.0f))
             return false;
+        hal.stepper.disable_motors((axes_signals_t){0}, SquaringMode_Both);
     }
 
     // The active cycle axes should now be homed and machine limits have been located. By


### PR DESCRIPTION
### Problem

Commit 41abd8c removed the `hal.stepper.disable_motors((axes_signals_t){0}, SquaringMode_Both)` call that ran after the dual axis offset pull-off move at the end of homing, in `homing_cycle()`.

That pull-off is the compensation move for switch misalignment, and it deliberately masks off one of the two motors of the auto squared axis so only the other one moves:

```c
if(auto_square.mask && settings.axis[dual_motor_axis].dual_axis_offset != 0.0f) {
    hal.stepper.disable_motors(auto_square, settings.axis[dual_motor_axis].dual_axis_offset < 0.0f ? SquaringMode_B : SquaringMode_A);
    ...
    if(!limits_pull_off(auto_square, &distance, 1.0f))
        return false;
    // <-- restore to SquaringMode_Both used to happen here
}
```

With the restore gone, the masked motor stays step-disabled after homing completes. The axis then runs on a single motor for all subsequent motion — jogging, gcode, everything — until a soft reset, since `grbllib.c` restores `SquaringMode_Both` on reset. A negative offset strands the second motor, a positive offset strands the first.

The per-cycle squaring mask set during the homing search itself is fine; it is restored inside the homing loop. Only the final offset pull-off is affected, which is why this only shows up when `$17n` is non-zero.

### Reproduction

On a board with `Y_AUTO_SQUARE=1` (STM32F4xx, LongBoard32 EXT, `N_AXIS=4`):

1. Set `$171=-0.5`
2. Home. Both Y motors move correctly through the whole homing cycle, including squaring.
3. Jog Y. Only Y1 moves; Y2 is dead.
4. Soft reset. Y2 works again, until the next homing cycle.

With `$171=0` the buggy block is skipped entirely and everything behaves, which makes this easy to mistake for a corrupted setting.

### Fix

Restore the call, so both motors are re-enabled once the pull-off completes. This is a straight revert of the deleted line, no behaviour change beyond that.

### Note, not addressed here

The `return false` on pull-off failure also leaves the block with a motor still masked off. That predates 41abd8c, so I have left it alone to keep this a pure revert of the regression, but you may want to handle it in the same pass.
