### PR TITLE
Fix vfs path overflow

### DIFF
--- a/vfs.c
+++ b/vfs.c
@@ -432,6 +432,11 @@ int vfs_chdir (const char *path)
     vfs_errno = 0;
     path = parse_path(path);
 
+    if(strlen(path) >= sizeof(cwd)) { // Fail if the normalized path would not fit the cwd buffer.
+        vfs_errno = -1;
+        return -1;
+    }
+
     if((mount = get_mount(path))) {
         if(mount->vfs->fchdir)
             ret = mount->vfs->fchdir(get_filename(mount, path));

--- a/vfs.c
+++ b/vfs.c
@@ -230,17 +230,20 @@ char *vfs_fixpath (char *path)
 
 static const char *parse_path (const char *path)
 {
-    static char *abspath;
-    static size_t maxlen = 0;
+    static char *abspath, *newpath;
+    static size_t maxlen = 0, newpathlen = 0;
 
     if(strlen(cwd) + strlen(path) + 2 > maxlen) {
         maxlen = max(VFS_CWD_LENGTH, strlen(cwd) + strlen(path) + 2);
         abspath = realloc(abspath, maxlen);
     }
 
-    if(abspath) {
+    if(strlen(path) + 1 > newpathlen) {
+        newpathlen = max(VFS_CWD_LENGTH, strlen(path) + 1);
+        newpath = realloc(newpath, newpathlen);
+    }
 
-        char newpath[VFS_CWD_LENGTH];
+    if(abspath && newpath) {
 
         strcpy(newpath, path);
         strcpy(abspath, *path == '/' ? "/" : cwd);
@@ -260,9 +263,9 @@ static const char *parse_path (const char *path)
             el = strtok(NULL, "/");
         }
     } else
-        maxlen = 0;
+        maxlen = newpathlen = 0;
 
-    return abspath ? (const char *)abspath : path;
+    return abspath && newpath ? (const char *)abspath : path;
 }
 
 static vfs_mount_t *get_mount (const char *path)


### PR DESCRIPTION
Two fixed-size buffers in the VFS layer are written with unbounded copies of
a caller-supplied path, so a path at or above `VFS_CWD_LENGTH` (default 100)
overflows them. Both are reachable through `vfs_chdir()` and `vfs_stat()`,
i.e. from any file-serving plugin that passes an external path (SD file
browser, FTP `CWD`/stat, WebDAV) as well as local operations on deep
directory trees.

1. `parse_path()` copies the path into a fixed 100-byte stack buffer,
   `char newpath[VFS_CWD_LENGTH]`, with `strcpy()` and no length check —
   even though `abspath` in the same function is already `realloc`-grown to
   fit. The `strcpy` runs before any existence check, so it fires on the raw
   input regardless of whether the path is valid.
2. `vfs_chdir()` copies the normalized path into the fixed `cwd` buffer with
   `strcpy(cwd, path)`. `parse_path()` can return a path longer than
   `VFS_CWD_LENGTH`, so changing into a directory whose absolute path exceeds
   the buffer overflows the static `cwd` array.

These have been latent because everyday paths are short, but both corrupt the
stack / static state on overflow.

# Fix

- `parse_path()`: grow the tokenizer scratch buffer with `realloc` to fit the
  path, using the same idiom already applied to `abspath`, and fall back to
  returning the path unchanged if either allocation fails. Long paths continue
  to normalize correctly.
- `vfs_chdir()`: reject a normalized path that does not fit the `cwd` buffer
  before attempting the change, leaving the current directory and filesystem
  state untouched. This matches the existing fixed-size `cwd` contract and is
  strictly safer than the previous overflow.



**I highly doubt this is a real-world issue on machines since if everyone else is like me their paths are "/surfacing1.nc" "/skiproughing.nc" "oops.nc", but seemed like an easy fix to prevent future issues.**