### PR TITLE
ngc_flowctrl: close named-subroutine file redirects when unwinding the stack

### DIFF
--- a/ngc_flowctrl.c
+++ b/ngc_flowctrl.c
@@ -321,8 +321,11 @@ FLASHMEM static void stack_unwind_sub (uint32_t o_label)
 FLASHMEM void ngc_flowctrl_unwind_stack (vfs_file_t *file)
 {
     clear_subs(file);
-    while(stack_idx >= 0 && stack[stack_idx].file == file)
+    while(stack_idx >= 0 && stack[stack_idx].file == file) {
+        if(stack[stack_idx].o_label > NGC_MAX_PARAM_ID)
+            stream_redirect_close(stack[stack_idx].file);
         stack_pull();
+    }
 }
 
 FLASHMEM static status_code_t onGcodeComment (char *comment)
@@ -358,8 +361,15 @@ FLASHMEM void ngc_flowctrl_init (void)
     }
 
     clear_subs(NULL);
-    while(stack_idx >= 0)
+    // Close any still-open named-subroutine file redirect before dropping this stack entry - a Reset
+    // landing mid-O-call previously left hal.stream.read permanently stuck on the file reader
+    // (stream_file.c's stream_read_file), since this loop only cleared the stack's own bookkeeping.
+    // Mirrors stack_unwind_sub()'s handling of the same entry kind.
+    while(stack_idx >= 0) {
+        if(stack[stack_idx].o_label > NGC_MAX_PARAM_ID)
+            stream_redirect_close(stack[stack_idx].file);
         stack_pull();
+    }
 }
 
 // NOTE: onNamedSubError will be called recursively for each


### PR DESCRIPTION
## Summary
Both stack-unwind paths in `ngc_flowctrl.c` - `ngc_flowctrl_init()` (called from `gc_init()` on every soft reset) and `ngc_flowctrl_unwind_stack()` (called on normal macro completion, e.g. from the sdcard macros plugin's `end_macro()`) - drop stack entries via a bare `stack_pull()` loop, which only clears that file's own bookkeeping. Unlike the sibling function `stack_unwind_sub()` in the same file, neither ever calls `stream_redirect_close()` for named-subroutine entries (`o_label > NGC_MAX_PARAM_ID`, i.e. entries that actually opened a file via `stream_redirect_read()`).

**Consequence:** a Reset (or, for the second function, even ordinary cleanup of a nested named O-word subroutine call) landing while such a redirect is active leaves `hal.stream.read` permanently stuck on `stream_read_file` (`stream_file.c`) - a self-sustaining loop that keeps returning stale data from the no-longer-relevant file handle, needing no new real input to sustain it.

## Repro / verification
Reproduced on a Teensy 4.1 (iMXRT1062 driver): Reset landing during a named O-word subroutine call streamed from a file (a "Start Job" macro sequence) left the controller needing a full power-cycle to recover - `$X`/`$H` bytes never reached the parser, since `hal.stream.read()` was serving stale file content forever. Transport-independent (reproduced identically over both Serial and Telnet), and confirmed via a raw function-pointer dump that `hal.stream.read` resolved to `stream_read_file` during the hang.

Fix mirrors `stack_unwind_sub()`'s existing handling of the same entry kind: call `stream_redirect_close()` for any named-subroutine stack entry before pulling it, in both unwind loops. Verified fixed on hardware - Reset now correctly puts the controller in a normal `Alarm` state, and `$X` clears it as expected.

## Test plan
- [x] Builds clean (Teensy 4.1 / PlatformIO)
- [x] Hardware-reproduced the bug before the fix, and hardware-verified resolved after
