### PR TITLE
grbllib: flush the output stream buffer on reset, not just the input buffer

### DIFF
--- a/grbllib.c
+++ b/grbllib.c
@@ -484,6 +484,8 @@ FLASHMEM int grbl_enter (void)
 
         // Reset primary systems.
         hal.stream.reset_read_buffer();                 // Clear input stream buffer
+        if(hal.stream.reset_write_buffer)
+            hal.stream.reset_write_buffer();            // Clear output stream buffer
         gc_init(settings.flags.keep_offsets_on_reset);  // Set g-code parser to default state
         hal.limits.enable(settings.limits.flags.hard_enabled, (axes_signals_t){0});
         plan_reset();                                   // Clear block buffer and planner variables


### PR DESCRIPTION
## Summary
`hal.stream.reset_read_buffer()` is called on every reboot to clear pending input, but there was no equivalent call for the output side. `reset_write_buffer` is defined in the HAL stream interface (optional, documented for Modbus/RS-485 support) and at least one driver (`Plugin_networking`'s `telnetd.c`) already implements it - but nothing in the core reboot sequence ever called it, on any transport.

**Consequence:** a stale, partially-transmitted TX message left in a driver's output buffer across a reset can leak out merged with the reboot's own output, with no separator - observed as a garbled/concatenated ALARM message (e.g. `Alarm:-1` instead of a clean `Alarm:3 - Reset/E-stop while in motion...`) immediately following a Reset-during-motion repro.

## Repro / verification
Reproduced identically on both Serial and Telnet on a Teensy 4.1 (iMXRT1062 driver) during a Reset-during-motion repro. After the fix, the `ALARM:` line prints cleanly on every repro attempt.

## Fix
Call `hal.stream.reset_write_buffer()` (guarded, since it's optional per the HAL interface) right alongside the existing `reset_read_buffer()` call in the reboot sequence.

## Test plan
- [x] Builds clean (Teensy 4.1 / PlatformIO)
- [x] Hardware-reproduced the corruption before the fix, and hardware-verified resolved after (identical on Serial and Telnet)
