### PR TITLE
Fix for potential stack frame overflow in vfs.c fs_stat()

### DIFF
--- a/vfs.c
+++ b/vfs.c
@@ -151,10 +151,19 @@ static void fs_closedir (vfs_dir_t *dir)
 
 static int fs_stat (const char *filename, vfs_stat_t *st)
 {
-    char path[64];
+    char path[64], *fpath = path;
     vfs_mount_t *mount;
+    size_t len = strlen(filename) + 2; // leading '/' + terminating '\0'
 
-    if((mount = path_is_mount_dir(strcat(strcpy(path, "/"), filename)))) {
+    if(len > sizeof(path) && (fpath = malloc(len)) == NULL)
+        return (vfs_errno = -1);
+
+    mount = path_is_mount_dir(strcat(strcpy(fpath, "/"), filename));
+
+    if(fpath != path)
+        free(fpath);
+
+    if(mount) {
 
         if(!(mount->vfs->fstat && (vfs_errno = mount->vfs->fstat("/", st) == 0))) {
 


### PR DESCRIPTION
fs_stat() in vfs.c builds the path it looks up like this:

```c
static int fs_stat (const char *filename, vfs_stat_t *st)
{
    char path[64];
    vfs_mount_t *mount;

    if((mount = path_is_mount_dir(strcat(strcpy(path, "/"), filename)))) {
```

There's no check anywhere that `"/" + filename` actually fits in the 64-byte stack buffer. Any filename of 63 bytes or more overflows it. That's not a particularly exotic input - a normal nested path on an SD card or LittleFS volume, or a path coming in over FTP/WebDAV/the WebUI file browser once a network plugin is enabled, can easily be that long.

I noticed this is the same class of bug that commit c84cda0 (following PR #986) just fixed for `parse_path()` and `vfs_chdir()` elsewhere in this same file - "correctly handle long working directory paths that would otherwise lead to buffer overflows". `fs_stat()` just wasn't part of that change and still has the old fixed-size, unchecked copy.

I fixed it the same way the rest of that recent work handles it: keep the 64-byte stack buffer for the normal short-path case (no behavior change there), and fall back to a heap allocation sized to the actual path when it doesn't fit, rather than silently overflowing:

```c
static int fs_stat (const char *filename, vfs_stat_t *st)
{
    char path[64], *fpath = path;
    vfs_mount_t *mount;
    size_t len = strlen(filename) + 2; // leading '/' + terminating '\0'

    if(len > sizeof(path) && (fpath = malloc(len)) == NULL)
        return (vfs_errno = -1);

    mount = path_is_mount_dir(strcat(strcpy(fpath, "/"), filename));

    if(fpath != path)
        free(fpath);

    if(mount) {
        ...
```

To verify this without an embedded target, I pulled the exact function body (both before and after the fix) into a standalone harness and wrapped the stack buffer in a struct with a canary right after it, since C guarantees struct members keep their declared order. With the original code, filenames up to 62 bytes leave the canary untouched, 63 bytes corrupts the first canary byte, and it gets worse from there - a 150-byte filename overflows far enough to crash the process outright on return. With the patched version I re-ran the same lengths (up to 10000 bytes) and the canary stays intact every time, the heap path only kicks in once the name genuinely doesn't fit (matching the `len > sizeof(path)` check exactly), and malloc/free stay paired 1:1 with no leaks.

Only vfs.c is touched, no signature/behavior change for the normal case.