### PR TITLE
Fix for reporting of updated overrides on reset

### DIFF
--- a/grbllib.c
+++ b/grbllib.c
@@ -481,6 +481,7 @@ FLASHMEM int grbl_enter (void)
             sys.override.control.parking_disable = settings.parking.flags.deactivate_upon_init;
 
         flush_override_buffers();
+        report_add_realtime(Report_Overrides);
 
         // Reset primary systems.
         hal.stream.reset_read_buffer();                 // Clear input stream buffer


### PR DESCRIPTION
Currently it seems that if `$676` is configured to clear override values on reset, this change is not reported to a keypad display.

The proposed fix is just a single line addition in the reset loop to set the override reporting flag. This has been tested to work with the RP2040 driver and the latest version of the keypad plugin with I2C display (**DISPLAY_ENABLE=9**).