### PR TITLE
Add read-only planner export API for external motion drivers.

### DIFF
--- a/core_handlers.h
+++ b/core_handlers.h
@@ -88,6 +88,7 @@ typedef bool (*home_machine_ptr)(axes_signals_t cycle, axes_signals_t auto_squar
 typedef void (*on_parser_init_ptr)(parser_state_t *gc_state);
 typedef void (*on_state_change_ptr)(sys_state_t state);
 typedef void (*on_override_changed_ptr)(override_changed_t override);
+typedef void (*on_planner_changed_ptr)(void);
 typedef void (*on_spindle_programmed_ptr)(spindle_ptrs_t *spindle, spindle_state_t state, float rpm, spindle_rpm_mode_t mode);
 typedef void (*on_spindle_at_speed_ptr)(spindle_ptrs_t *spindle, spindle_state_t state);
 typedef void (*on_port_out_ptr)(uint8_t port, io_port_type_t type, float value);
@@ -228,6 +229,7 @@ typedef struct {
     on_parser_init_ptr on_parser_init;
     on_state_change_ptr on_state_change;
     on_override_changed_ptr on_override_changed;
+    on_planner_changed_ptr on_planner_changed;                  //!< Called when the planner buffer contents or the computed velocity profile change. May be called from the stepper prep context, keep the handler short.
     on_report_handlers_init_ptr on_report_handlers_init;
     on_spindle_programmed_ptr on_spindle_programmed;
     on_spindle_at_speed_ptr on_spindle_at_speed;

--- a/planner.c
+++ b/planner.c
@@ -51,6 +51,24 @@ typedef struct {
 static planner_t pl;
 static block_buffer_t block_buffer;
 
+// Revision counter for the plan export API. Incremented by plan_signal_changed() every time the buffer
+// contents or the computed velocity profile change. Declared volatile as it is read from a different
+// context (a subscribing driver/plugin) than the one mutating the plan.
+static volatile uint32_t plan_revision = 0;
+
+// Records that the planner buffer contents or the computed velocity profile have changed.
+// Bumps the revision counter polled via plan_get_revision() and notifies any subscriber so it can
+// re-export the plan. Kept as a single choke point so every mutation path stays in sync.
+static void plan_signal_changed (void)
+{
+    plan_revision++;
+
+    // Notify a subscribed driver/plugin. This may be reached from the stepper prep context when a
+    // block is consumed, so subscribers must keep the handler short (typically just set a flag).
+    if(grbl.on_planner_changed)
+        grbl.on_planner_changed();
+}
+
 /*                            PLANNER SPEED DEFINITION
                                      +--------+   <- current->nominal_speed
                                     /          \
@@ -257,6 +275,8 @@ FLASHMEM bool plan_reset (void)
 
     plan_reset_buffer(&block_buffer, block_buffer.blocks[0].next == NULL);
 
+    plan_signal_changed(); // Buffer emptied.
+
     return true;
 }
 
@@ -268,6 +288,8 @@ void plan_discard_current_block (void)
         if (block_buffer.tail == block_buffer.planned)
             block_buffer.planned = block_buffer.tail->next;
         block_buffer.tail = block_buffer.tail->next;
+
+        plan_signal_changed(); // A block was consumed, the set of executing/queued blocks changed.
     }
 }
 
@@ -290,6 +312,64 @@ plan_block_t *plan_get_current_block (void)
 plan_block_t *plan_get_recent_block (void)
 {
     return block_buffer.head == block_buffer.tail ? NULL : block_buffer.head->prev;
+}
+
+
+// Returns the current plan revision. See declaration in planner.h for usage.
+uint32_t plan_get_revision (void)
+{
+    return plan_revision;
+}
+
+
+// Starts a read-only iteration over the planner buffer. See declaration in planner.h.
+bool plan_export_first (plan_export_cursor_t *cursor, plan_export_block_t *block)
+{
+    // Capture the revision so the caller can detect whether the plan changed mid-iteration.
+    cursor->revision = plan_revision;
+    // Begin at the buffer tail (block being executed or first to execute), NULL when the buffer is empty.
+    cursor->block = plan_get_current_block();
+    // Blocks are stable until the optimally planned pointer is reached, see plan_export_next().
+    cursor->stable = true;
+
+    return plan_export_next(cursor, block);
+}
+
+
+// Continues an iteration started by plan_export_first(). See declaration in planner.h.
+bool plan_export_next (plan_export_cursor_t *cursor, plan_export_block_t *block)
+{
+    plan_block_t *current = cursor->block;
+
+    // No (more) blocks to export.
+    if(current == NULL)
+        return false;
+
+    // The buffer head is the always-empty slot following the last queued block, so a next pointer that
+    // reaches the head means the current block is the last (newest) one in the buffer.
+    plan_block_t *next = current->next;
+    bool next_is_valid = next != block_buffer.head;
+
+    // block_buffer.planned points to the first block after the last optimally planned block. Once it is
+    // reached the remaining blocks may still be re-planned, so they are reported as not yet stable.
+    if(current == block_buffer.planned)
+        cursor->stable = false;
+
+    // Populate the caller supplied read-only view from the internal block.
+    block->identity = current;
+    memcpy(block->target_mm, current->target_mm, sizeof(block->target_mm));
+    block->profile_velocity = plan_compute_profile_nominal_speed(current);
+    // Exit speed of block N is the entry speed of block N+1; the newest block always plans to a stop.
+    block->end_velocity = next_is_valid ? sqrtf(next->entry_speed_sqr) : 0.0f;
+    block->acceleration = current->acceleration;
+    block->condition = current->condition;
+    block->line_number = current->line_number;
+    block->stable = cursor->stable;
+
+    // Advance the cursor, stopping when the head (empty slot) is reached.
+    cursor->block = next_is_valid ? next : NULL;
+
+    return true;
 }
 
 
@@ -659,6 +739,8 @@ bool plan_buffer_line (float *target, plan_line_data_t *pl_data)
 
         // Finish up by recalculating the plan with the new block.
         planner_recalculate();
+
+        plan_signal_changed(); // A new block was queued and the velocity profile recomputed.
     }
 
     return true;
@@ -708,6 +790,8 @@ void plan_cycle_reinitialize (void)
     st_update_plan_block_parameters(false);
     if((block_buffer.planned = block_buffer.tail) != block_buffer.head)
         planner_recalculate();
+
+    plan_signal_changed(); // Velocity profile re-planned after a feed hold, override or RPM change.
 }
 
 // Re-calculates buffered motions profile parameters upon a motion-based override change.

--- a/planner.h
+++ b/planner.h
@@ -168,6 +168,30 @@ typedef struct {
   } override;
 } planner_t;
 
+// Read-only, driver facing view of a single planner block.
+// This is a stable abstraction of the internal plan_block_t: it exposes only the values a higher
+// level motion consumer (e.g. an external motion controller driver) needs, so the internal block
+// layout can change without breaking consumers. Populated by plan_export_first()/plan_export_next().
+typedef struct {
+    const void *identity;           // Stable identifier of the block (its buffer address) for as long as the block exists.
+    float target_mm[N_AXIS];        // Absolute target position of the move in mm.
+    float profile_velocity;         // Nominal (cruise) velocity for the block in mm/min, feed/rapid override adjusted.
+    float end_velocity;             // Exit (junction) velocity in mm/min, i.e. the entry velocity of the following block. Zero at the buffer end.
+    float acceleration;             // Effective acceleration used to plan the block in mm/min^2.
+    planner_cond_t condition;       // Copy of the block run conditions (motion type, overrides disabled, spindle sync etc.).
+    line_number_t line_number;      // G-code line number associated with the block, 0 if none.
+    bool stable;                    // True when the block lies within the optimally planned region and its velocities will not change with future planning.
+} plan_export_block_t;
+
+// Cursor used to iterate a snapshot of the planner buffer with plan_export_first()/plan_export_next().
+// The cursor is owned by the caller but must be treated as opaque; its fields are maintained by the
+// export functions and should not be modified directly.
+typedef struct {
+    plan_block_t *block;            // Internal iterator, points to the next block to export or NULL when the buffer end is reached.
+    uint32_t revision;              // Value of plan_get_revision() captured when the iteration was started, for detecting concurrent changes.
+    bool stable;                    // Running state of the "stable" flag, cleared once the optimally planned pointer is reached.
+} plan_export_cursor_t;
+
 // Initialize and reset the motion plan subsystem
 bool plan_reset (void); // Reset all
 
@@ -190,6 +214,19 @@ plan_block_t *plan_get_current_block (void);
 
 // Gets last added block. Returns NULL if buffer empty
 plan_block_t *plan_get_recent_block (void);
+
+// Returns a monotonically increasing counter that changes whenever the planner buffer contents or the
+// computed velocity profile change. A consumer can poll this to detect when a re-export is required.
+uint32_t plan_get_revision (void);
+
+// Starts a read-only iteration over the planner buffer, from the block currently being executed to the
+// most recently queued block, populating *block with the first entry. Returns false and leaves *block
+// untouched when the buffer is empty.
+bool plan_export_first (plan_export_cursor_t *cursor, plan_export_block_t *block);
+
+// Continues an iteration started by plan_export_first(), populating *block with the next entry.
+// Returns false when no more blocks are available.
+bool plan_export_next (plan_export_cursor_t *cursor, plan_export_block_t *block);
 
 // Called by step segment buffer when computing executing block velocity profile.
 float plan_get_exec_block_exit_speed_sqr (void);


### PR DESCRIPTION
Some drivers need access to the planned motion queue above the HAL stepper interface, for example to feed an external motion controller that does not share the same step/dir execution model. This adds a small, additive API that lets a driver or plugin read the current planner buffer without exposing the internal plan_block_t layout.

Changes:
- planner.h: add plan_export_block_t and plan_export_cursor_t, plus plan_get_revision(), plan_export_first() and plan_export_next().
- planner.c: add a volatile plan revision counter and plan_signal_changed() choke point, called whenever the buffer contents or computed velocity profile change (reset, queue, discard, re-plan). Export returns target, nominal velocity, exit velocity, acceleration, condition, line number, and a stable flag derived from block_buffer.planned.
- core_handlers.h: add grbl.on_planner_changed so subscribers can react when the plan changes. Keep the handler short; it may run from stepper prep context.

The export API is read-only and does not alter existing planner behaviour. No existing functions or structs were changed.