### PR TITLE
gcode: guard NULL chained on_settings_changed in onSettingsChanged

### DIFF
--- a/gcode.c
+++ b/gcode.c
@@ -753,7 +753,8 @@ static void onSettingsChanged (settings_t *settings, settings_changed_flags_t ch
     if(changed.spindle || changed.restore_defaults)
         gc_spindle_off();
 
-    settings_changed(settings, changed);
+    if(settings_changed)
+        settings_changed(settings, changed);
 }
 
 FLASHMEM void gc_init (bool stop)


### PR DESCRIPTION
`gc_init()` subscribes to `grbl.on_settings_changed` by capturing the previous handler so it can chain it:

```c
if(settings_changed == NULL) {
    settings_changed = grbl.on_settings_changed;   // may legitimately be NULL
    grbl.on_settings_changed = onSettingsChanged;
}
```

When no plugin or driver has subscribed before the first `gc_init()` runs, the captured pointer is NULL, and the chained call at the top of `onSettingsChanged()` dereferences it. On builds with no other subscriber, every runtime `$`-setting write then crashes (observed live with the Simulator: any `$xx=yy` segfaulted).

The core dispatcher in grbllib.c already NULL-checks its own `grbl.on_settings_changed` before calling; this adds the same guard to the chained tail in gcode.c. No behavior change when a subscriber exists.

Reproduce (before this fix): build the Simulator, connect, send any `$`-setting write, e.g. `$110=6000` - the process crashes in `onSettingsChanged()`.